### PR TITLE
Register ConfiguredFeatures without suppliers and fixed double registration of regular Features

### DIFF
--- a/src/main/java/cy/jdkdigital/productivebees/ProductiveBees.java
+++ b/src/main/java/cy/jdkdigital/productivebees/ProductiveBees.java
@@ -138,52 +138,52 @@ public final class ProductiveBees
         Biome.Category category = event.getCategory();
         // Add biome features
         if (category.equals(Biome.Category.DESERT)) {
-            event.getGeneration().withFeature(GenerationStage.Decoration.TOP_LAYER_MODIFICATION, ModFeatures.SAND_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.SAND.getDefaultState(), ModBlocks.SAND_NEST.get().getDefaultState())));
+            event.getGeneration().withFeature(GenerationStage.Decoration.TOP_LAYER_MODIFICATION, ModConfiguredFeatures.SAND_NEST_FEATURE);
         }
         else if (category.equals(Biome.Category.SAVANNA) || category.equals(Biome.Category.TAIGA)) {
-            event.getGeneration().withFeature(GenerationStage.Decoration.TOP_LAYER_MODIFICATION, ModConfiguredFeatures.COARSE_DIRT_NEST_FEATURE.get());
-            event.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, ModConfiguredFeatures.SPRUCE_WOOD_NEST_FEATURE.get());
-            event.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, ModConfiguredFeatures.ACACIA_WOOD_NEST_FEATURE.get());
+            event.getGeneration().withFeature(GenerationStage.Decoration.TOP_LAYER_MODIFICATION, ModConfiguredFeatures.COARSE_DIRT_NEST_FEATURE);
+            event.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, ModConfiguredFeatures.SPRUCE_WOOD_NEST_FEATURE);
+            event.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, ModConfiguredFeatures.ACACIA_WOOD_NEST_FEATURE);
         }
         else if (category.equals(Biome.Category.JUNGLE)) {
-            event.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, ModConfiguredFeatures.JUNGLE_WOOD_NEST_FEATURE.get());
+            event.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, ModConfiguredFeatures.JUNGLE_WOOD_NEST_FEATURE);
         }
         else if (category.equals(Biome.Category.FOREST)) {
-            event.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, ModConfiguredFeatures.OAK_WOOD_NEST_FEATURE.get());
-            event.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, ModConfiguredFeatures.DARK_OAK_WOOD_NEST_FEATURE.get());
-            event.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, ModConfiguredFeatures.BIRCH_WOOD_NEST_FEATURE.get());
+            event.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, ModConfiguredFeatures.OAK_WOOD_NEST_FEATURE);
+            event.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, ModConfiguredFeatures.DARK_OAK_WOOD_NEST_FEATURE);
+            event.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, ModConfiguredFeatures.BIRCH_WOOD_NEST_FEATURE);
         }
         else if (category.equals(Biome.Category.EXTREME_HILLS)) {
-            event.getGeneration().withFeature(GenerationStage.Decoration.TOP_LAYER_MODIFICATION, ModConfiguredFeatures.STONE_NEST_FEATURE.get());
-            event.getGeneration().withFeature(GenerationStage.Decoration.TOP_LAYER_MODIFICATION, ModConfiguredFeatures.SNOW_NEST_FEATURE.get());
-            event.getGeneration().withFeature(GenerationStage.Decoration.TOP_LAYER_MODIFICATION, ModConfiguredFeatures.SNOW_NEST_BLOCK_FEATURE.get());
+            event.getGeneration().withFeature(GenerationStage.Decoration.TOP_LAYER_MODIFICATION, ModConfiguredFeatures.STONE_NEST_FEATURE);
+            event.getGeneration().withFeature(GenerationStage.Decoration.TOP_LAYER_MODIFICATION, ModConfiguredFeatures.SNOW_NEST_FEATURE);
+            event.getGeneration().withFeature(GenerationStage.Decoration.TOP_LAYER_MODIFICATION, ModConfiguredFeatures.SNOW_NEST_BLOCK_FEATURE);
         }
         else if (category.equals(Biome.Category.SWAMP)) {
-            event.getGeneration().withFeature(GenerationStage.Decoration.TOP_LAYER_MODIFICATION, ModConfiguredFeatures.SLIMY_NEST_FEATURE.get());
+            event.getGeneration().withFeature(GenerationStage.Decoration.TOP_LAYER_MODIFICATION, ModConfiguredFeatures.SLIMY_NEST_FEATURE);
         }
         else if (category.equals(Biome.Category.NETHER)) {
-            event.getGeneration().withFeature(GenerationStage.Decoration.UNDERGROUND_DECORATION, ModConfiguredFeatures.GLOWSTONE_NEST_FEATURE.get());
-            event.getGeneration().withFeature(GenerationStage.Decoration.UNDERGROUND_ORES, ModConfiguredFeatures.NETHER_QUARTZ_NEST_FEATURE.get());
-            event.getGeneration().withFeature(GenerationStage.Decoration.TOP_LAYER_MODIFICATION, ModConfiguredFeatures.NETHER_QUARTZ_NEST_HIGH_FEATURE.get());
-            event.getGeneration().withFeature(GenerationStage.Decoration.TOP_LAYER_MODIFICATION, ModConfiguredFeatures.NETHER_FORTRESS_NEST_FEATURE.get());
-            event.getGeneration().withFeature(GenerationStage.Decoration.UNDERGROUND_DECORATION, ModConfiguredFeatures.SOUL_SAND_NEST_FEATURE.get());
+            event.getGeneration().withFeature(GenerationStage.Decoration.UNDERGROUND_DECORATION, ModConfiguredFeatures.GLOWSTONE_NEST_FEATURE);
+            event.getGeneration().withFeature(GenerationStage.Decoration.UNDERGROUND_ORES, ModConfiguredFeatures.NETHER_QUARTZ_NEST_FEATURE);
+            event.getGeneration().withFeature(GenerationStage.Decoration.TOP_LAYER_MODIFICATION, ModConfiguredFeatures.NETHER_QUARTZ_NEST_HIGH_FEATURE);
+            event.getGeneration().withFeature(GenerationStage.Decoration.TOP_LAYER_MODIFICATION, ModConfiguredFeatures.NETHER_FORTRESS_NEST_FEATURE);
+            event.getGeneration().withFeature(GenerationStage.Decoration.UNDERGROUND_DECORATION, ModConfiguredFeatures.SOUL_SAND_NEST_FEATURE);
         }
         else if (category.equals(Biome.Category.RIVER) || category.equals(Biome.Category.BEACH)) {
             if (event.getClimate().temperatureModifier != Biome.TemperatureModifier.FROZEN) {
-                event.getGeneration().withFeature(GenerationStage.Decoration.TOP_LAYER_MODIFICATION, ModConfiguredFeatures.GRAVEL_NEST_FEATURE.get());
+                event.getGeneration().withFeature(GenerationStage.Decoration.TOP_LAYER_MODIFICATION, ModConfiguredFeatures.GRAVEL_NEST_FEATURE);
             }
         }
         else if (category.equals(Biome.Category.THEEND)) {
             if (event.getName().getPath().equals("the_end")) {
                 // Pillar nests
-                event.getGeneration().withFeature(GenerationStage.Decoration.TOP_LAYER_MODIFICATION, ModConfiguredFeatures.OBSIDIAN_PILLAR_NEST_FEATURE.get());
+                event.getGeneration().withFeature(GenerationStage.Decoration.TOP_LAYER_MODIFICATION, ModConfiguredFeatures.OBSIDIAN_PILLAR_NEST_FEATURE);
             } else {
                 // Must spawn where chorus fruit exist
-                event.getGeneration().withFeature(GenerationStage.Decoration.TOP_LAYER_MODIFICATION, ModConfiguredFeatures.END_NEST_FEATURE.get());
+                event.getGeneration().withFeature(GenerationStage.Decoration.TOP_LAYER_MODIFICATION, ModConfiguredFeatures.END_NEST_FEATURE);
             }
         }
         if (!category.equals(Biome.Category.THEEND) && !category.equals(Biome.Category.NETHER)) {
-            event.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, ModConfiguredFeatures.SUGAR_CANE_NEST_FEATURE.get());
+            event.getGeneration().withFeature(GenerationStage.Decoration.VEGETAL_DECORATION, ModConfiguredFeatures.SUGAR_CANE_NEST_FEATURE);
         }
     }
 

--- a/src/main/java/cy/jdkdigital/productivebees/init/ModConfiguredFeatures.java
+++ b/src/main/java/cy/jdkdigital/productivebees/init/ModConfiguredFeatures.java
@@ -8,10 +8,7 @@ import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.WorldGenRegistries;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.gen.GenerationStage;
-import net.minecraft.world.gen.feature.ConfiguredFeature;
-import net.minecraft.world.gen.feature.Feature;
-import net.minecraft.world.gen.feature.IFeatureConfig;
-import net.minecraft.world.gen.feature.ReplaceBlockConfig;
+import net.minecraft.world.gen.feature.*;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.RegistryObject;
 import net.minecraftforge.fml.common.Mod;
@@ -24,53 +21,52 @@ import java.util.function.Supplier;
 @Mod.EventBusSubscriber(modid = ProductiveBees.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
 public class ModConfiguredFeatures
 {
-    public static Supplier<ConfiguredFeature<?, ?>> SAND_NEST_FEATURE = () -> ModFeatures.SAND_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.SAND.getDefaultState(), ModBlocks.SAND_NEST.get().getDefaultState()));
-    public static Supplier<ConfiguredFeature<?, ?>> COARSE_DIRT_NEST_FEATURE = () -> ModFeatures.COARSE_DIRT_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.COARSE_DIRT.getDefaultState(), ModBlocks.COARSE_DIRT_NEST.get().getDefaultState()));
-    public static Supplier<ConfiguredFeature<?, ?>> SPRUCE_WOOD_NEST_FEATURE = () -> ModFeatures.SPRUCE_WOOD_NEST_FEATURE.get().withConfiguration(new ReplaceBlockConfig(Blocks.SPRUCE_LOG.getDefaultState(), ModBlocks.SPRUCE_WOOD_NEST.get().getDefaultState()));
-    public static Supplier<ConfiguredFeature<?, ?>> ACACIA_WOOD_NEST_FEATURE = () -> ModFeatures.ACACIA_WOOD_NEST_FEATURE.get().withConfiguration(new ReplaceBlockConfig(Blocks.ACACIA_LOG.getDefaultState(), ModBlocks.ACACIA_WOOD_NEST.get().getDefaultState()));
-    public static Supplier<ConfiguredFeature<?, ?>> JUNGLE_WOOD_NEST_FEATURE = () -> ModFeatures.JUNGLE_WOOD_NEST_FEATURE.get().withConfiguration(new ReplaceBlockConfig(Blocks.JUNGLE_LOG.getDefaultState(), ModBlocks.JUNGLE_WOOD_NEST.get().getDefaultState()));
-    public static Supplier<ConfiguredFeature<?, ?>> OAK_WOOD_NEST_FEATURE = () -> ModFeatures.OAK_WOOD_NEST_FEATURE.get().withConfiguration(new ReplaceBlockConfig(Blocks.OAK_LOG.getDefaultState(), ModBlocks.OAK_WOOD_NEST.get().getDefaultState()));
-    public static Supplier<ConfiguredFeature<?, ?>> DARK_OAK_WOOD_NEST_FEATURE = () -> ModFeatures.DARK_OAK_WOOD_NEST_FEATURE.get().withConfiguration(new ReplaceBlockConfig(Blocks.DARK_OAK_LOG.getDefaultState(), ModBlocks.DARK_OAK_WOOD_NEST.get().getDefaultState()));
-    public static Supplier<ConfiguredFeature<?, ?>> BIRCH_WOOD_NEST_FEATURE = () -> ModFeatures.BIRCH_WOOD_NEST_FEATURE.get().withConfiguration(new ReplaceBlockConfig(Blocks.BIRCH_LOG.getDefaultState(), ModBlocks.BIRCH_WOOD_NEST.get().getDefaultState()));
-    public static Supplier<ConfiguredFeature<?, ?>> STONE_NEST_FEATURE = () -> ModFeatures.STONE_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.STONE.getDefaultState(), ModBlocks.STONE_NEST.get().getDefaultState()));
-    public static Supplier<ConfiguredFeature<?, ?>> SNOW_NEST_FEATURE = () -> ModFeatures.SNOW_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.SNOW.getDefaultState(), ModBlocks.SNOW_NEST.get().getDefaultState()));
-    public static Supplier<ConfiguredFeature<?, ?>> SNOW_NEST_BLOCK_FEATURE = () -> ModFeatures.SNOW_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.SNOW_BLOCK.getDefaultState(), ModBlocks.SNOW_NEST.get().getDefaultState()));
-    public static Supplier<ConfiguredFeature<?, ?>> SLIMY_NEST_FEATURE = () -> ModFeatures.SLIMY_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.GRASS_BLOCK.getDefaultState(), ModBlocks.SLIMY_NEST.get().getDefaultState()));
-    public static Supplier<ConfiguredFeature<?, ?>> GLOWSTONE_NEST_FEATURE = () -> ModFeatures.GLOWSTONE_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.GLOWSTONE.getDefaultState(), ModBlocks.GLOWSTONE_NEST.get().getDefaultState()));
-    public static Supplier<ConfiguredFeature<?, ?>> NETHER_QUARTZ_NEST_FEATURE = () -> ModFeatures.NETHER_QUARTZ_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.NETHER_QUARTZ_ORE.getDefaultState(), ModBlocks.NETHER_QUARTZ_NEST.get().getDefaultState()));
-    public static Supplier<ConfiguredFeature<?, ?>> NETHER_QUARTZ_NEST_HIGH_FEATURE = () -> ModFeatures.NETHER_QUARTZ_NEST_HIGH.get().withConfiguration(new ReplaceBlockConfig(Blocks.NETHER_QUARTZ_ORE.getDefaultState(), ModBlocks.NETHER_QUARTZ_NEST.get().getDefaultState()));
-    public static Supplier<ConfiguredFeature<?, ?>> NETHER_FORTRESS_NEST_FEATURE = () -> ModFeatures.NETHER_FORTRESS_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.NETHER_BRICKS.getDefaultState(), ModBlocks.NETHER_BRICK_NEST.get().getDefaultState()));
-    public static Supplier<ConfiguredFeature<?, ?>> SOUL_SAND_NEST_FEATURE = () -> ModFeatures.SOUL_SAND_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.SOUL_SAND.getDefaultState(), ModBlocks.SOUL_SAND_NEST.get().getDefaultState()));
-    public static Supplier<ConfiguredFeature<?, ?>> GRAVEL_NEST_FEATURE = () -> ModFeatures.GRAVEL_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.GRAVEL.getDefaultState(), ModBlocks.GRAVEL_NEST.get().getDefaultState()));
-    public static Supplier<ConfiguredFeature<?, ?>> OBSIDIAN_PILLAR_NEST_FEATURE = () -> ModFeatures.OBSIDIAN_PILLAR_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.OBSIDIAN.getDefaultState(), ModBlocks.OBSIDIAN_PILLAR_NEST.get().getDefaultState()));
-    public static Supplier<ConfiguredFeature<?, ?>> END_NEST_FEATURE = () -> ModFeatures.END_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.END_STONE.getDefaultState(), ModBlocks.END_NEST.get().getDefaultState()));
-    public static Supplier<ConfiguredFeature<?, ?>> SUGAR_CANE_NEST_FEATURE = () -> ModFeatures.SUGAR_CANE_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.SUGAR_CANE.getDefaultState(), ModBlocks.SUGAR_CANE_NEST.get().getDefaultState()));
+    public static ConfiguredFeature<?, ?> SAND_NEST_FEATURE;
+    public static ConfiguredFeature<?, ?> COARSE_DIRT_NEST_FEATURE;
+    public static ConfiguredFeature<?, ?> SPRUCE_WOOD_NEST_FEATURE;
+    public static ConfiguredFeature<?, ?> ACACIA_WOOD_NEST_FEATURE;
+    public static ConfiguredFeature<?, ?> JUNGLE_WOOD_NEST_FEATURE;
+    public static ConfiguredFeature<?, ?> OAK_WOOD_NEST_FEATURE;
+    public static ConfiguredFeature<?, ?> DARK_OAK_WOOD_NEST_FEATURE;
+    public static ConfiguredFeature<?, ?> BIRCH_WOOD_NEST_FEATURE;
+    public static ConfiguredFeature<?, ?> STONE_NEST_FEATURE;
+    public static ConfiguredFeature<?, ?> SNOW_NEST_FEATURE;
+    public static ConfiguredFeature<?, ?> SNOW_NEST_BLOCK_FEATURE;
+    public static ConfiguredFeature<?, ?> SLIMY_NEST_FEATURE;
+    public static ConfiguredFeature<?, ?> GLOWSTONE_NEST_FEATURE;
+    public static ConfiguredFeature<?, ?> NETHER_QUARTZ_NEST_FEATURE;
+    public static ConfiguredFeature<?, ?> NETHER_QUARTZ_NEST_HIGH_FEATURE;
+    public static ConfiguredFeature<?, ?> NETHER_FORTRESS_NEST_FEATURE;
+    public static ConfiguredFeature<?, ?> SOUL_SAND_NEST_FEATURE;
+    public static ConfiguredFeature<?, ?> GRAVEL_NEST_FEATURE;
+    public static ConfiguredFeature<?, ?> OBSIDIAN_PILLAR_NEST_FEATURE;
+    public static ConfiguredFeature<?, ?> END_NEST_FEATURE;
+    public static ConfiguredFeature<?, ?> SUGAR_CANE_NEST_FEATURE;
 
     public static void registerConfiguredFeatures() {
         Registry<ConfiguredFeature<?, ?>> registry = WorldGenRegistries.CONFIGURED_FEATURE;
 
-        Registry.register(registry, rLoc("sand_nest_feature"), SAND_NEST_FEATURE.get());
-        Registry.register(registry, rLoc("snow_nest_feature"), SNOW_NEST_FEATURE.get());
-        Registry.register(registry, rLoc("snow_block_nest_feature"), SNOW_NEST_BLOCK_FEATURE.get());
-        Registry.register(registry, rLoc("stone_nest_feature"), STONE_NEST_FEATURE.get());
-        Registry.register(registry, rLoc("coarse_dirt_nest_feature"), COARSE_DIRT_NEST_FEATURE.get());
-        Registry.register(registry, rLoc("gravel_nest_feature"), GRAVEL_NEST_FEATURE.get());
-        Registry.register(registry, rLoc("slimy_nest_feature"), SLIMY_NEST_FEATURE.get());
-        Registry.register(registry, rLoc("sugar_cane_nest_feature"), SUGAR_CANE_NEST_FEATURE.get());
-        Registry.register(registry, rLoc("glowstone_nest_feature"), GLOWSTONE_NEST_FEATURE.get());
-        Registry.register(registry, rLoc("nether_quartz_nest_feature"), NETHER_QUARTZ_NEST_FEATURE.get());
-        Registry.register(registry, rLoc("nether_quarts_high_nest_feature"), NETHER_QUARTZ_NEST_HIGH_FEATURE.get());
-        Registry.register(registry, rLoc("nether_fortress_nest_feature"), NETHER_FORTRESS_NEST_FEATURE.get());
-        Registry.register(registry, rLoc("soul_sand_nest_feature"), SOUL_SAND_NEST_FEATURE.get());
-        Registry.register(registry, rLoc("end_nest_feature"), END_NEST_FEATURE.get());
-        Registry.register(registry, rLoc("obsidian_pillar_nest_feature"), OBSIDIAN_PILLAR_NEST_FEATURE.get());
-
-        Registry.register(registry, rLoc("oak_wood_nest_feature"), OAK_WOOD_NEST_FEATURE.get());
-        Registry.register(registry, rLoc("spruce_wood_nest_feature"), SPRUCE_WOOD_NEST_FEATURE.get());
-        Registry.register(registry, rLoc("birch_wood_nest_feature"), BIRCH_WOOD_NEST_FEATURE.get());
-        Registry.register(registry, rLoc("dark_oak_wood_nest_feature"), DARK_OAK_WOOD_NEST_FEATURE.get());
-        Registry.register(registry, rLoc("jungle_wood_nest_feature"), JUNGLE_WOOD_NEST_FEATURE.get());
-        Registry.register(registry, rLoc("acacia_wood_nest_feature"), ACACIA_WOOD_NEST_FEATURE.get());
+        SAND_NEST_FEATURE = Registry.register(registry, rLoc("sand_nest_feature"), ModFeatures.SAND_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.SAND.getDefaultState(), ModBlocks.SAND_NEST.get().getDefaultState())));
+        COARSE_DIRT_NEST_FEATURE = Registry.register(registry, rLoc("coarse_dirt_nest_feature"), ModFeatures.COARSE_DIRT_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.COARSE_DIRT.getDefaultState(), ModBlocks.COARSE_DIRT_NEST.get().getDefaultState())));
+        SPRUCE_WOOD_NEST_FEATURE = Registry.register(registry, rLoc("spruce_wood_nest_feature"), ModFeatures.SPRUCE_WOOD_NEST_FEATURE.get().withConfiguration(new ReplaceBlockConfig(Blocks.SPRUCE_LOG.getDefaultState(), ModBlocks.SPRUCE_WOOD_NEST.get().getDefaultState())));
+        ACACIA_WOOD_NEST_FEATURE = Registry.register(registry, rLoc("acacia_wood_nest_feature"), ModFeatures.ACACIA_WOOD_NEST_FEATURE.get().withConfiguration(new ReplaceBlockConfig(Blocks.ACACIA_LOG.getDefaultState(), ModBlocks.ACACIA_WOOD_NEST.get().getDefaultState())));
+        JUNGLE_WOOD_NEST_FEATURE = Registry.register(registry, rLoc("jungle_wood_nest_feature"), ModFeatures.JUNGLE_WOOD_NEST_FEATURE.get().withConfiguration(new ReplaceBlockConfig(Blocks.JUNGLE_LOG.getDefaultState(), ModBlocks.JUNGLE_WOOD_NEST.get().getDefaultState())));
+        OAK_WOOD_NEST_FEATURE = Registry.register(registry, rLoc("oak_wood_nest_feature"), ModFeatures.OAK_WOOD_NEST_FEATURE.get().withConfiguration(new ReplaceBlockConfig(Blocks.OAK_LOG.getDefaultState(), ModBlocks.OAK_WOOD_NEST.get().getDefaultState())));
+        DARK_OAK_WOOD_NEST_FEATURE = Registry.register(registry, rLoc("dark_oak_wood_nest_feature"), ModFeatures.DARK_OAK_WOOD_NEST_FEATURE.get().withConfiguration(new ReplaceBlockConfig(Blocks.DARK_OAK_LOG.getDefaultState(), ModBlocks.DARK_OAK_WOOD_NEST.get().getDefaultState())));
+        BIRCH_WOOD_NEST_FEATURE = Registry.register(registry, rLoc("birch_wood_nest_feature"), ModFeatures.BIRCH_WOOD_NEST_FEATURE.get().withConfiguration(new ReplaceBlockConfig(Blocks.BIRCH_LOG.getDefaultState(), ModBlocks.BIRCH_WOOD_NEST.get().getDefaultState())));
+        STONE_NEST_FEATURE = Registry.register(registry, rLoc("stone_nest_feature"), ModFeatures.STONE_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.STONE.getDefaultState(), ModBlocks.STONE_NEST.get().getDefaultState())));
+        SNOW_NEST_FEATURE = Registry.register(registry, rLoc("snow_nest_feature"), ModFeatures.SNOW_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.SNOW.getDefaultState(), ModBlocks.SNOW_NEST.get().getDefaultState())));
+        SNOW_NEST_BLOCK_FEATURE = Registry.register(registry, rLoc("snow_nest_block_feature"), ModFeatures.SNOW_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.SNOW_BLOCK.getDefaultState(), ModBlocks.SNOW_NEST.get().getDefaultState())));
+        SLIMY_NEST_FEATURE = Registry.register(registry, rLoc("slimy_nest_feature"), ModFeatures.SLIMY_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.GRASS_BLOCK.getDefaultState(), ModBlocks.SLIMY_NEST.get().getDefaultState())));
+        GLOWSTONE_NEST_FEATURE = Registry.register(registry, rLoc("glowstone_nest_feature"), ModFeatures.GLOWSTONE_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.GLOWSTONE.getDefaultState(), ModBlocks.GLOWSTONE_NEST.get().getDefaultState())));
+        NETHER_QUARTZ_NEST_FEATURE = Registry.register(registry, rLoc("nether_quartz_nest_feature"), ModFeatures.NETHER_QUARTZ_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.NETHER_QUARTZ_ORE.getDefaultState(), ModBlocks.NETHER_QUARTZ_NEST.get().getDefaultState())));
+        NETHER_QUARTZ_NEST_HIGH_FEATURE = Registry.register(registry, rLoc("nether_quartz_nest_high_feature"), ModFeatures.NETHER_QUARTZ_NEST_HIGH.get().withConfiguration(new ReplaceBlockConfig(Blocks.NETHER_QUARTZ_ORE.getDefaultState(), ModBlocks.NETHER_QUARTZ_NEST.get().getDefaultState())));
+        NETHER_FORTRESS_NEST_FEATURE = Registry.register(registry, rLoc("nether_fortress_nest_feature"), ModFeatures.NETHER_FORTRESS_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.NETHER_BRICKS.getDefaultState(), ModBlocks.NETHER_BRICK_NEST.get().getDefaultState())));
+        SOUL_SAND_NEST_FEATURE = Registry.register(registry, rLoc("soul_sand_nest_feature"), ModFeatures.SOUL_SAND_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.SOUL_SAND.getDefaultState(), ModBlocks.SOUL_SAND_NEST.get().getDefaultState())));
+        GRAVEL_NEST_FEATURE = Registry.register(registry, rLoc("gravel_nest_feature"), ModFeatures.GRAVEL_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.GRAVEL.getDefaultState(), ModBlocks.GRAVEL_NEST.get().getDefaultState())));
+        OBSIDIAN_PILLAR_NEST_FEATURE = Registry.register(registry, rLoc("obsidian_pillar_nest_feature"), ModFeatures.OBSIDIAN_PILLAR_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.OBSIDIAN.getDefaultState(), ModBlocks.OBSIDIAN_PILLAR_NEST.get().getDefaultState())));
+        END_NEST_FEATURE = Registry.register(registry, rLoc("end_nest_feature"), ModFeatures.END_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.END_STONE.getDefaultState(), ModBlocks.END_NEST.get().getDefaultState())));
+        SUGAR_CANE_NEST_FEATURE = Registry.register(registry, rLoc("sugar_cane_nest_feature"), ModFeatures.SUGAR_CANE_NEST.get().withConfiguration(new ReplaceBlockConfig(Blocks.SUGAR_CANE.getDefaultState(), ModBlocks.SUGAR_CANE_NEST.get().getDefaultState())));
     }
     
     private static ResourceLocation rLoc(String name) {

--- a/src/main/java/cy/jdkdigital/productivebees/init/ModFeatures.java
+++ b/src/main/java/cy/jdkdigital/productivebees/init/ModFeatures.java
@@ -48,32 +48,6 @@ public class ModFeatures
     }
 
     public static void registerFeatures(RegistryEvent.Register<Feature<?>> event) {
-        IForgeRegistry<Feature<?>> featureRegistry = event.getRegistry();
-
-        registerFeature(featureRegistry, SAND_NEST.get(), SAND_NEST.getId());
-        registerFeature(featureRegistry, SNOW_NEST.get(), SNOW_NEST.getId());
-        registerFeature(featureRegistry, STONE_NEST.get(), STONE_NEST.getId());
-        registerFeature(featureRegistry, COARSE_DIRT_NEST.get(), COARSE_DIRT_NEST.getId());
-        registerFeature(featureRegistry, GRAVEL_NEST.get(), GRAVEL_NEST.getId());
-        registerFeature(featureRegistry, SLIMY_NEST.get(), SLIMY_NEST.getId());
-        registerFeature(featureRegistry, SUGAR_CANE_NEST.get(), SUGAR_CANE_NEST.getId());
-        registerFeature(featureRegistry, GLOWSTONE_NEST.get(), GLOWSTONE_NEST.getId());
-        registerFeature(featureRegistry, NETHER_QUARTZ_NEST.get(), NETHER_QUARTZ_NEST.getId());
-        registerFeature(featureRegistry, NETHER_QUARTZ_NEST_HIGH.get(), NETHER_QUARTZ_NEST_HIGH.getId());
-        registerFeature(featureRegistry, NETHER_FORTRESS_NEST.get(), NETHER_FORTRESS_NEST.getId());
-        registerFeature(featureRegistry, SOUL_SAND_NEST.get(), SOUL_SAND_NEST.getId());
-        registerFeature(featureRegistry, END_NEST.get(), END_NEST.getId());
-        registerFeature(featureRegistry, OBSIDIAN_PILLAR_NEST.get(), OBSIDIAN_PILLAR_NEST.getId());
-
-        registerFeature(featureRegistry, OAK_WOOD_NEST_FEATURE.get(), OAK_WOOD_NEST_FEATURE.getId());
-        registerFeature(featureRegistry, SPRUCE_WOOD_NEST_FEATURE.get(), SPRUCE_WOOD_NEST_FEATURE.getId());
-        registerFeature(featureRegistry, BIRCH_WOOD_NEST_FEATURE.get(), BIRCH_WOOD_NEST_FEATURE.getId());
-        registerFeature(featureRegistry, DARK_OAK_WOOD_NEST_FEATURE.get(), DARK_OAK_WOOD_NEST_FEATURE.getId());
-        registerFeature(featureRegistry, JUNGLE_WOOD_NEST_FEATURE.get(), JUNGLE_WOOD_NEST_FEATURE.getId());
-        registerFeature(featureRegistry, ACACIA_WOOD_NEST_FEATURE.get(), ACACIA_WOOD_NEST_FEATURE.getId());
-    }
-
-    public static <F extends Feature<?>> void registerFeature(IForgeRegistry<Feature<?>> registry, F feature, ResourceLocation resourceLocation) {
-        Registry.register(Registry.FEATURE, resourceLocation, feature);
+        // Static init the fields by classloading
     }
 }


### PR DESCRIPTION
Should resolve this issue once and for all!
https://github.com/JDKDigital/productive-bees/issues/94

The suppliers were returning a new instance of the configuredfeature every time that they were called which caused v0.4.1.1 to still have unregistered configuredfeatures. This PR removes the suppliers in favor of setting a static instance of the CFs when one is made and registered.

The Features were being registered twice so I just removed the vanilla registry from them as the forge registry is enough (it's just a wrapper around the vanilla registry so it doesnt matter which one the stuff is registered to). This should eliminate the log spam about things being registered multiple times