### PR TITLE
update advancement json for json format 8

### DIFF
--- a/src/main/resources/data/productivebees/advancements/husbandry/advanced_beehive/dragon_egg_hive.json
+++ b/src/main/resources/data/productivebees/advancements/husbandry/advanced_beehive/dragon_egg_hive.json
@@ -21,7 +21,9 @@
             "conditions": {
                 "items": [
                     {
-                        "item": "productivebees:dragon_egg_hive"
+                        "items": [
+                            "productivebees:dragon_egg_hive"
+                        ]
                     }
                 ]
             }

--- a/src/main/resources/data/productivebees/advancements/husbandry/advanced_beehive/dragon_egg_hive/convert_egg.json
+++ b/src/main/resources/data/productivebees/advancements/husbandry/advanced_beehive/dragon_egg_hive/convert_egg.json
@@ -25,7 +25,9 @@
                     }
                 },
                 "item": {
-                    "item": "minecraft:dragon_breath"
+                    "items": [
+                        "minecraft:dragon_breath"
+                    ]
                 }
             }
         }

--- a/src/main/resources/data/productivebees/advancements/husbandry/advanced_beehive/expansion_box/hive_upgrades.json
+++ b/src/main/resources/data/productivebees/advancements/husbandry/advanced_beehive/expansion_box/hive_upgrades.json
@@ -21,7 +21,9 @@
             "conditions": {
                 "items": [
                     {
-                        "item": "productivebees:upgrade_base"
+                        "items": [
+                            "productivebees:upgrade_base"
+                        ]
                     }
                 ]
             }

--- a/src/main/resources/data/productivebees/advancements/husbandry/bee_cage.json
+++ b/src/main/resources/data/productivebees/advancements/husbandry/bee_cage.json
@@ -21,7 +21,9 @@
             "conditions": {
                 "items": [
                     {
-                        "item": "productivebees:bee_cage"
+                        "items": [
+                            "productivebees:bee_cage"
+                        ]
                     }
                 ]
             }

--- a/src/main/resources/data/productivebees/advancements/husbandry/bee_cage/nest_locator.json
+++ b/src/main/resources/data/productivebees/advancements/husbandry/bee_cage/nest_locator.json
@@ -21,7 +21,9 @@
             "conditions": {
                 "items": [
                     {
-                        "item": "productivebees:nest_locator"
+                        "items": [
+                            "productivebees:nest_locator"
+                        ]
                     }
                 ]
             }

--- a/src/main/resources/data/productivebees/advancements/husbandry/bee_cage/overworld_nest/consume_sugarbag_comb.json
+++ b/src/main/resources/data/productivebees/advancements/husbandry/bee_cage/overworld_nest/consume_sugarbag_comb.json
@@ -20,7 +20,9 @@
             "trigger": "minecraft:consume_item",
             "conditions": {
                 "item": {
-                    "item": "productivebees:sugarbag_honeycomb"
+                    "items": [
+                        "productivebees:sugarbag_honeycomb"
+                    ]
                 }
             }
         }

--- a/src/main/resources/data/productivebees/advancements/husbandry/bee_cage/overworld_nest/treat_on_nest.json
+++ b/src/main/resources/data/productivebees/advancements/husbandry/bee_cage/overworld_nest/treat_on_nest.json
@@ -25,7 +25,9 @@
                     }
                 },
                 "item": {
-                    "item": "productivebees:honey_treat"
+                    "items": [
+                        "productivebees:honey_treat"
+                    ]
                 }
             }
         }

--- a/src/main/resources/data/productivebees/advancements/husbandry/bee_cage/professional_bee/feeding_slab.json
+++ b/src/main/resources/data/productivebees/advancements/husbandry/bee_cage/professional_bee/feeding_slab.json
@@ -21,7 +21,9 @@
             "conditions": {
                 "items": [
                     {
-                        "item": "productivebees:feeder"
+                        "items": [
+                            "productivebees:feeder"
+                        ]
                     }
                 ]
             }

--- a/src/main/resources/data/productivebees/advancements/husbandry/bee_cage/quartz_nest.json
+++ b/src/main/resources/data/productivebees/advancements/husbandry/bee_cage/quartz_nest.json
@@ -21,7 +21,9 @@
             "conditions": {
                 "items": [
                     {
-                        "item": "productivebees:nether_quartz_nest"
+                        "items": [
+                            "productivebees:nether_quartz_nest"
+                        ]
                     }
                 ]
             }


### PR DESCRIPTION
as i noted in my issue for nature's aura over at https://github.com/Ellpeck/NaturesAura/issues/231 the json format for advancements changed, causing hilarity like:
![image](https://user-images.githubusercontent.com/1569754/147005956-06a00360-f755-4049-aa59-4dfc66b42610.png)
(triggered by receiving an iron helmet, which is why suit up is in that list)
and
![image](https://user-images.githubusercontent.com/1569754/147005978-04458674-6213-4172-b74d-1e496875c4dd.png)
(triggered by placing a wooden plank on the ground)

fixing the json was easy, but as far as i can tell the catch bee triggers aren't working either, and i suspect the other custom advancement triggers are also broken, but that isn't a "really quick knock it out" change the way this json is. (and advancements failing to fire, while undesirable, is less disruptive than advancement spam)

fixes #217 