### PR TITLE
Fix for ConcurrentModificationException during mod startup

### DIFF
--- a/src/main/java/cy/jdkdigital/productivebees/ProductiveBees.java
+++ b/src/main/java/cy/jdkdigital/productivebees/ProductiveBees.java
@@ -7,7 +7,6 @@ import cy.jdkdigital.productivebees.common.block.DragonEggHive;
 import cy.jdkdigital.productivebees.common.crafting.conditions.BeeExistsCondition;
 import cy.jdkdigital.productivebees.common.crafting.conditions.FluidTagEmptyCondition;
 import cy.jdkdigital.productivebees.common.entity.bee.ConfigurableBee;
-import cy.jdkdigital.productivebees.common.item.BeeCage;
 import cy.jdkdigital.productivebees.dispenser.CageDispenseBehavior;
 import cy.jdkdigital.productivebees.dispenser.ShearsDispenseItemBehavior;
 import cy.jdkdigital.productivebees.event.EventHandler;
@@ -15,13 +14,11 @@ import cy.jdkdigital.productivebees.init.*;
 import cy.jdkdigital.productivebees.integrations.top.TopPlugin;
 import cy.jdkdigital.productivebees.network.PacketHandler;
 import cy.jdkdigital.productivebees.network.packets.Messages;
-import cy.jdkdigital.productivebees.setup.*;
-import cy.jdkdigital.productivebees.util.BeeHelper;
+import cy.jdkdigital.productivebees.setup.BeeReloadListener;
+import cy.jdkdigital.productivebees.setup.ClientProxy;
+import cy.jdkdigital.productivebees.setup.IProxy;
+import cy.jdkdigital.productivebees.setup.ServerProxy;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.BlockSource;
-import net.minecraft.core.Direction;
-import net.minecraft.core.dispenser.DefaultDispenseItemBehavior;
-import net.minecraft.core.dispenser.OptionalDispenseItemBehavior;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
@@ -29,7 +26,6 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.village.poi.PoiType;
-import net.minecraft.world.entity.animal.Bee;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -38,7 +34,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.DispenserBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.feature.Feature;
-import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.crafting.CraftingHelper;
@@ -47,7 +42,6 @@ import net.minecraftforge.event.OnDatapackSyncEvent;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.world.BiomeLoadingEvent;
-import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.InterModComms;
@@ -60,6 +54,7 @@ import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.GameData;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -99,11 +94,6 @@ public final class ProductiveBees
         ModRecipeTypes.RECIPE_SERIALIZERS.register(modEventBus);
         ModParticles.PARTICLE_TYPES.register(modEventBus);
         ModLootModifiers.LOOT_SERIALIZERS.register(modEventBus);
-
-        DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> {
-            modEventBus.addListener(ClientSetup::init);
-            modEventBus.addListener(EventPriority.LOWEST, ClientSetup::registerParticles);
-        });
 
         modEventBus.addListener(this::onInterModEnqueue);
         modEventBus.addGenericListener(Feature.class, this::onRegisterFeatures);
@@ -191,7 +181,7 @@ public final class ProductiveBees
         ImmutableList<Block> beehives = ForgeRegistries.BLOCKS.getValues().stream().filter(block -> block instanceof AdvancedBeehive && !(block instanceof DragonEggHive)).collect(ImmutableList.toImmutableList());
         for (Block block : beehives) {
             for (BlockState state : block.getStateDefinition().getPossibleStates()) {
-                PoiType.TYPE_BY_STATE.put(state, PoiType.BEEHIVE);
+                GameData.getBlockStatePointOfInterestTypeMap().put(state, PoiType.BEEHIVE);
                 try {
                     PoiType.BEEHIVE.matchingStates.add(state);
                 } catch (Exception e) {

--- a/src/main/java/cy/jdkdigital/productivebees/setup/ClientSetup.java
+++ b/src/main/java/cy/jdkdigital/productivebees/setup/ClientSetup.java
@@ -1,5 +1,6 @@
 package cy.jdkdigital.productivebees.setup;
 
+import cy.jdkdigital.productivebees.ProductiveBees;
 import cy.jdkdigital.productivebees.client.particle.*;
 import cy.jdkdigital.productivebees.client.render.block.BottlerTileEntityRenderer;
 import cy.jdkdigital.productivebees.client.render.block.CentrifugeTileEntityRenderer;
@@ -16,7 +17,6 @@ import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.RenderType;
-import net.minecraft.client.renderer.blockentity.BlockEntityRenderers;
 import net.minecraft.client.renderer.item.ClampedItemPropertyFunction;
 import net.minecraft.client.renderer.item.ItemProperties;
 import net.minecraft.core.BlockPos;
@@ -26,75 +26,86 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.decoration.ItemFrame;
 import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.EntityRenderersEvent.RegisterRenderers;
 import net.minecraftforge.client.event.ParticleFactoryRegisterEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+@Mod.EventBusSubscriber(modid = ProductiveBees.MODID, bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
 public class ClientSetup
 {
+    @SubscribeEvent
     public static void init(final FMLClientSetupEvent event) {
-        MenuScreens.register(ModContainerTypes.ADVANCED_BEEHIVE.get(), AdvancedBeehiveScreen::new);
-        MenuScreens.register(ModContainerTypes.CENTRIFUGE.get(), CentrifugeScreen::new);
-        MenuScreens.register(ModContainerTypes.POWERED_CENTRIFUGE.get(), CentrifugeScreen::new);
-        MenuScreens.register(ModContainerTypes.BOTTLER.get(), BottlerScreen::new);
-        MenuScreens.register(ModContainerTypes.FEEDER.get(), FeederScreen::new);
-        MenuScreens.register(ModContainerTypes.INCUBATOR.get(), IncubatorScreen::new);
-        MenuScreens.register(ModContainerTypes.CATCHER.get(), CatcherScreen::new);
-        MenuScreens.register(ModContainerTypes.HONEY_GENERATOR.get(), HoneyGeneratorScreen::new);
-        MenuScreens.register(ModContainerTypes.GENE_INDEXER.get(), GeneIndexerScreen::new);
+        event.enqueueWork(() -> {
+            MenuScreens.register(ModContainerTypes.ADVANCED_BEEHIVE.get(), AdvancedBeehiveScreen::new);
+            MenuScreens.register(ModContainerTypes.CENTRIFUGE.get(), CentrifugeScreen::new);
+            MenuScreens.register(ModContainerTypes.POWERED_CENTRIFUGE.get(), CentrifugeScreen::new);
+            MenuScreens.register(ModContainerTypes.BOTTLER.get(), BottlerScreen::new);
+            MenuScreens.register(ModContainerTypes.FEEDER.get(), FeederScreen::new);
+            MenuScreens.register(ModContainerTypes.INCUBATOR.get(), IncubatorScreen::new);
+            MenuScreens.register(ModContainerTypes.CATCHER.get(), CatcherScreen::new);
+            MenuScreens.register(ModContainerTypes.HONEY_GENERATOR.get(), HoneyGeneratorScreen::new);
+            MenuScreens.register(ModContainerTypes.GENE_INDEXER.get(), GeneIndexerScreen::new);
 
-        ItemProperties.register(ModItems.BEE_CAGE.get(), new ResourceLocation("filled"), (stack, world, entity, i) -> BeeCage.isFilled(stack) ? 1.0F : 0.0F);
-        ItemProperties.register(ModItems.STURDY_BEE_CAGE.get(), new ResourceLocation("filled"), (stack, world, entity, i) -> BeeCage.isFilled(stack) ? 1.0F : 0.0F);
-        ItemProperties.register(ModItems.BEE_BOMB.get(), new ResourceLocation("loaded"), (stack, world, entity, i) -> BeeBomb.isLoaded(stack) ? 1.0F : 0.0F);
-        ItemProperties.register(ModItems.HONEY_TREAT.get(), new ResourceLocation("genetic"), (stack, world, entity, i) -> HoneyTreat.hasGene(stack) ? 1.0F : 0.0F);
-        ItemProperties.register(ModItems.NEST_LOCATOR.get(), new ResourceLocation("angle"), new ClampedItemPropertyFunction()
-        {
-            public float unclampedCall(@Nonnull ItemStack stack, @Nullable ClientLevel world, @Nullable LivingEntity player, int i) {
-                if ((player != null || stack.isFramed()) && NestLocator.hasPosition(stack)) {
-                    boolean flag = player != null;
-                    Entity entity = flag ? player : stack.getFrame();
-                    if (world == null && entity != null && entity.level instanceof ClientLevel) {
-                        world = (ClientLevel) entity.level;
-                    }
-                    BlockPos pos = NestLocator.getPosition(stack);
-                    if (entity != null && world != null && pos != null) {
-                        double d1 = flag ? (double) entity.getYRot() : this.getFrameRotation((ItemFrame) entity);
-                        d1 = Mth.positiveModulo(d1 / 360.0D, 1.0D);
-                        double d2 = this.getPositionToAngle(pos, entity) / (double) ((float) Math.PI * 2F);
-                        double d0 = 0.5D - (d1 - 0.25D - d2);
+            ItemProperties.register(ModItems.BEE_CAGE.get(), new ResourceLocation("filled"), (stack, world, entity, i) -> BeeCage.isFilled(stack) ? 1.0F : 0.0F);
+            ItemProperties.register(ModItems.STURDY_BEE_CAGE.get(), new ResourceLocation("filled"), (stack, world, entity, i) -> BeeCage.isFilled(stack) ? 1.0F : 0.0F);
+            ItemProperties.register(ModItems.BEE_BOMB.get(), new ResourceLocation("loaded"), (stack, world, entity, i) -> BeeBomb.isLoaded(stack) ? 1.0F : 0.0F);
+            ItemProperties.register(ModItems.HONEY_TREAT.get(), new ResourceLocation("genetic"), (stack, world, entity, i) -> HoneyTreat.hasGene(stack) ? 1.0F : 0.0F);
+            ItemProperties.register(ModItems.NEST_LOCATOR.get(), new ResourceLocation("angle"), new ClampedItemPropertyFunction() {
+                public float unclampedCall(@Nonnull ItemStack stack, @Nullable ClientLevel world, @Nullable LivingEntity player, int i) {
+                    if ((player != null || stack.isFramed()) && NestLocator.hasPosition(stack)) {
+                        boolean flag = player != null;
+                        Entity entity = flag ? player : stack.getFrame();
+                        if (world == null && entity != null && entity.level instanceof ClientLevel) {
+                            world = (ClientLevel) entity.level;
+                        }
+                        BlockPos pos = NestLocator.getPosition(stack);
+                        if (entity != null && world != null && pos != null) {
+                            double d1 = flag ? (double) entity.getYRot() : this.getFrameRotation((ItemFrame) entity);
+                            d1 = Mth.positiveModulo(d1 / 360.0D, 1.0D);
+                            double d2 = this.getPositionToAngle(pos, entity) / (double) ((float) Math.PI * 2F);
+                            double d0 = 0.5D - (d1 - 0.25D - d2);
 
-                        return Mth.positiveModulo((float) d0, 1.0F);
+                            return Mth.positiveModulo((float) d0, 1.0F);
+                        }
                     }
+                    return 0.5F;
                 }
-                return 0.5F;
-            }
 
-            private double getFrameRotation(ItemFrame frameEntity) {
-                return Mth.wrapDegrees(180 + frameEntity.getDirection().get2DDataValue() * 90);
-            }
+                private double getFrameRotation(ItemFrame frameEntity) {
+                    return Mth.wrapDegrees(180 + frameEntity.getDirection().get2DDataValue() * 90);
+                }
 
-            private double getPositionToAngle(BlockPos blockpos, Entity entityIn) {
-                return Math.atan2((double) blockpos.getZ() - entityIn.getZ(), (double) blockpos.getX() - entityIn.getX());
-            }
+                private double getPositionToAngle(BlockPos blockpos, Entity entityIn) {
+                    return Math.atan2((double) blockpos.getZ() - entityIn.getZ(), (double) blockpos.getX() - entityIn.getX());
+                }
+            });
         });
-
-        BlockEntityRenderers.register(ModTileEntityTypes.CENTRIFUGE.get(), CentrifugeTileEntityRenderer::new);
-        BlockEntityRenderers.register(ModTileEntityTypes.POWERED_CENTRIFUGE.get(), CentrifugeTileEntityRenderer::new);
-        BlockEntityRenderers.register(ModTileEntityTypes.BOTTLER.get(), BottlerTileEntityRenderer::new);
-        BlockEntityRenderers.register(ModTileEntityTypes.FEEDER.get(), FeederTileEntityRenderer::new);
-        BlockEntityRenderers.register(ModTileEntityTypes.JAR.get(), JarTileEntityRenderer::new);
 
         registerBlockRendering();
     }
 
+    @SubscribeEvent
     public static void registerParticles(final ParticleFactoryRegisterEvent event) {
         Minecraft.getInstance().particleEngine.register(ModParticles.COLORED_FALLING_NECTAR.get(), FallingNectarParticle.FallingNectarFactory::new);
         Minecraft.getInstance().particleEngine.register(ModParticles.COLORED_RISING_NECTAR.get(), RisingNectarParticle.RisingNectarFactory::new);
         Minecraft.getInstance().particleEngine.register(ModParticles.COLORED_POPPING_NECTAR.get(), PoppingNectarParticle.PoppingNectarFactory::new);
         Minecraft.getInstance().particleEngine.register(ModParticles.COLORED_LAVA_NECTAR.get(), LavaNectarParticle.LavaNectarFactory::new);
         Minecraft.getInstance().particleEngine.register(ModParticles.COLORED_PORTAL_NECTAR.get(), PortalNectarParticle.PortalNectarFactory::new);
+    }
+
+    @SubscribeEvent
+    public static void registerEntityRenderers(RegisterRenderers event) {
+        event.registerBlockEntityRenderer(ModTileEntityTypes.CENTRIFUGE.get(), CentrifugeTileEntityRenderer::new);
+        event.registerBlockEntityRenderer(ModTileEntityTypes.POWERED_CENTRIFUGE.get(), CentrifugeTileEntityRenderer::new);
+        event.registerBlockEntityRenderer(ModTileEntityTypes.BOTTLER.get(), BottlerTileEntityRenderer::new);
+        event.registerBlockEntityRenderer(ModTileEntityTypes.FEEDER.get(), FeederTileEntityRenderer::new);
+        event.registerBlockEntityRenderer(ModTileEntityTypes.JAR.get(), JarTileEntityRenderer::new);
     }
 
     private static void registerBlockRendering() {

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,6 +1,5 @@
 # Make various Block related things public
 public-f net.minecraft.world.entity.ai.village.poi.PoiType f_27325_ # blockStates
-public-f net.minecraft.world.entity.ai.village.poi.PoiType f_27323_ # TYPE_BY_STATE
 public net.minecraft.world.entity.ai.village.poi.PoiType <init>(Ljava/lang/String;Ljava/util/Set;II)V # PointOfInterestType
 public net.minecraft.world.item.crafting.RecipeManager m_44054_(Lnet/minecraft/world/item/crafting/RecipeType;)Ljava/util/Map; # getRecipes
 public net.minecraft.world.item.crafting.RecipeManager f_44007_ # recipes


### PR DESCRIPTION
Upon loading a modpack with this mod I encountered an issue:
```
-- Head --
Thread: Render thread
Stacktrace:
	at java.util.HashMap.computeIfAbsent(HashMap.java:1221) ~[?:?] {re:mixin}
-- MOD productivebees --
Details:
	Mod File: productivebees-1.18.2-0.9.0.4.jar
	Failure message: Productive Bees (productivebees) encountered an error during the sided_setup event phase
		java.util.ConcurrentModificationException: null
	Mod Version: 1.18.2-0.9.0.4
	Mod Issue URL: https://github.com/JDKDigital/productive-bees/issues
	Exception message: java.util.ConcurrentModificationException
Stacktrace:
	at java.util.HashMap.computeIfAbsent(HashMap.java:1221) ~[?:?] {re:mixin}
	at net.minecraft.client.renderer.item.ItemProperties.register(ItemProperties.java:60) ~[client-1.18.2-20220404.173914-srg.jar%23356!/:?] {re:classloading,pl:runtimedistcleaner:A}
	at cy.jdkdigital.productivebees.setup.ClientSetup.init(ClientSetup.java:51) ~[productivebees-1.18.2-0.9.0.4.jar%23281!/:1.18.2-0.9.0.4] {re:classloading}
	at net.minecraftforge.eventbus.EventBus.doCastFilter(EventBus.java:247) ~[eventbus-5.0.3.jar%232!/:?] {}
	at net.minecraftforge.eventbus.EventBus.lambda$addListener$11(EventBus.java:239) ~[eventbus-5.0.3.jar%232!/:?] {}
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:302) ~[eventbus-5.0.3.jar%232!/:?] {}
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:283) ~[eventbus-5.0.3.jar%232!/:?] {}
	at net.minecraftforge.fml.javafmlmod.FMLModContainer.acceptEvent(FMLModContainer.java:106) ~[javafmllanguage-1.18.2-40.1.20.jar%23358!/:?] {}
	at net.minecraftforge.fml.ModContainer.lambda$buildTransitionHandler$4(ModContainer.java:107) ~[fmlcore-1.18.2-40.1.20.jar%23357!/:?] {}
	at java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804) ~[?:?] {}
	at java.util.concurrent.CompletableFuture$AsyncRun.exec(CompletableFuture.java:1796) ~[?:?] {}
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373) ~[?:?] {}
	at java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182) ~[?:?] {}
	at java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655) ~[?:?] {re:computing_frames}
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622) ~[?:?] {re:computing_frames}
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165) ~[?:?] {}
```

`FMLClientSetupEvent` is a parallel dispatch event and it's important to delegate any non-synchronized work to the main thread. This helps avoiding issues like the one above, or at least making sure that your mod is not responsible for causing them.

Additionally, I cleaned up the init code a bit by moving BERs into their own event and replacing the `DistExecutor` call with Forge annotations.

I also removed an AT for one field that was patched by Forge (since it has no effect on such fields). This was necessary to make the project load and fire up the game properly.