### PR TITLE
fix: bee not removed anymore if simulated hive on tick [intermittened issue]

### DIFF
--- a/src/main/java/cy/jdkdigital/productivebees/common/block/entity/AdvancedBeehiveBlockEntityAbstract.java
+++ b/src/main/java/cy/jdkdigital/productivebees/common/block/entity/AdvancedBeehiveBlockEntityAbstract.java
@@ -99,11 +99,12 @@ public abstract class AdvancedBeehiveBlockEntityAbstract extends BeehiveBlockEnt
         blockEntity.beeHandler.ifPresent(h -> {
             Iterator<Inhabitant> inhabitantIterator = h.getInhabitants().iterator();
             boolean hasReleased = false;
+            boolean isSimulatedHive = ProductiveBeesConfig.BEES.allowBeeSimulation.get() && blockEntity instanceof AdvancedBeehiveBlockEntity advancedBeehiveBlockEntity && advancedBeehiveBlockEntity.getUpgradeCount(ModItems.UPGRADE_SIMULATOR.get()) > 0;
             while (inhabitantIterator.hasNext()) {
                 Inhabitant inhabitant = inhabitantIterator.next();
                 if (inhabitant.ticksInHive > inhabitant.minOccupationTicks) {
                     BeehiveBlockEntity.BeeReleaseStatus beeState = inhabitant.nbt.getBoolean("HasNectar") ? BeehiveBlockEntity.BeeReleaseStatus.HONEY_DELIVERED : BeehiveBlockEntity.BeeReleaseStatus.BEE_RELEASED;
-                    if (ProductiveBeesConfig.BEES.allowBeeSimulation.get() && blockEntity instanceof AdvancedBeehiveBlockEntity advancedBeehiveBlockEntity && advancedBeehiveBlockEntity.getUpgradeCount(ModItems.UPGRADE_SIMULATOR.get()) > 0) {
+                    if (isSimulatedHive) {
                         // for simulated hives, count all the way up to timeInHive + pollinationTime
                         if (inhabitant.ticksInHive > (inhabitant.minOccupationTicks + 450)) {
                             simulateBee(level, hivePos, state, blockEntity, inhabitant);
@@ -112,7 +113,7 @@ public abstract class AdvancedBeehiveBlockEntityAbstract extends BeehiveBlockEnt
                             // only add count if outside is favourable
                             inhabitant.ticksInHive += blockEntity.tickCounter;
                         }
-                    } else if (releaseBee(level, hivePos, state, blockEntity, inhabitant.nbt, null, beeState)) {
+                    } else if (!isSimulatedHive && releaseBee(level, hivePos, state, blockEntity, inhabitant.nbt, null, beeState)) {
                         hasReleased = true;
                         inhabitantIterator.remove();
                     }


### PR DESCRIPTION
There is a bug in ATM 8 with simulated bee hives, where sometimes bees and beecages get deleted when inserting them into the hive. I have not yet fully found the reason why bees get deleted, but i assume that the "willLeaveHive" could be true which in turn then could result in releasing the bee, even though it should not be able to be released within a simulated hive.

The second fix i had in mind is surround the simulation hive logic with a try / catch and then populate the inventory with the correct cage item, to at least retrieve it in case something gets wrong. i hope to be able to debug that, and see where it actually fails. It might be that it thinks it is actually populated, but in concurrence with the bug on top, it gets a null pointer or something along those lines...

Not sure if any of this is the fault of this mod, or the modpack itself, feedback is welcome :)