### PR TITLE
Fix shift-clicking into advanced hives without expansion box or dragon egg hives

### DIFF
--- a/src/main/java/cy/jdkdigital/productivebees/container/AbstractContainer.java
+++ b/src/main/java/cy/jdkdigital/productivebees/container/AbstractContainer.java
@@ -42,7 +42,7 @@ abstract class AbstractContainer extends AbstractContainerMenu
                 }
             } else {
                 // Move from player inv into container
-                int upgradeSlotCount = this.getTileEntity() instanceof UpgradeableBlockEntity ? 4 : 0;
+                int upgradeSlotCount = this.getTileEntity() instanceof UpgradeableBlockEntity upgradeableBlockEntity && upgradeableBlockEntity.acceptsUpgrades() ? 4 : 0;
                 if (upgradeSlotCount > 0 && slotStack.getItem() instanceof UpgradeItem) {
                     if (!moveItemStackTo(slotStack, containerSlots - upgradeSlotCount, containerSlots, false)) {
                         return ItemStack.EMPTY;


### PR DESCRIPTION
Previously you couldn't shift-click into last 4 slots in some hives without expansion box, now it's fixed