### PR TITLE
Multiple fixes for feeding slab

### DIFF
--- a/src/main/java/cy/jdkdigital/productivebees/common/block/Feeder.java
+++ b/src/main/java/cy/jdkdigital/productivebees/common/block/Feeder.java
@@ -64,7 +64,7 @@ public class Feeder extends SlabBlock implements EntityBlock
         BlockState state = super.getStateForPlacement(context);
 
         FluidState fluidstate = context.getLevel().getFluidState(context.getClickedPos());
-        if (fluidstate.is(ModTags.HONEY) && state != null) {
+        if (fluidstate.is(ModTags.HONEY) && fluidstate.isSource() && state != null) {
             return state.setValue(HONEYLOGGED, true);
         }
         return state;
@@ -141,7 +141,8 @@ public class Feeder extends SlabBlock implements EntityBlock
             if (heldBlock instanceof SlabBlock) {
                 final BlockEntity blockEntity = world.getBlockEntity(pos);
                 if (blockEntity instanceof FeederBlockEntity) {
-                    ((FeederBlockEntity) blockEntity).baseBlock = heldBlock;
+                    ((FeederBlockEntity) blockEntity).baseBlock = heldBlock instanceof Feeder ? null : heldBlock;
+                    blockEntity.setChanged();
                     return InteractionResult.SUCCESS;
                 }
             }


### PR DESCRIPTION
- Fix feeding slab honey dupe (fixes partially #347)
- Fix feeding slab becoming invisible when clicked by a feeding slab
- Fix feeding slab not actually saving its "heldBlock" to disk (after restart having default texture instead of changed texture)