### PR TITLE
Fixed the "very high" productivity trait

### DIFF
--- a/src/main/java/cy/jdkdigital/productivebees/common/block/entity/AdvancedBeehiveBlockEntity.java
+++ b/src/main/java/cy/jdkdigital/productivebees/common/block/entity/AdvancedBeehiveBlockEntity.java
@@ -251,11 +251,15 @@ public class AdvancedBeehiveBlockEntity extends AdvancedBeehiveBlockEntityAbstra
                             if (beeEntity instanceof ProductiveBee) {
                                 int productivity = ((ProductiveBee) beeEntity).getAttributeValue(BeeAttributes.PRODUCTIVITY);
                                 if (productivity > 0) {
-                                    float modifier = (1f / (productivity + 2f) + (productivity + 1f) / 2f) * stack.getCount();
-                                    stack.grow(Math.round(modifier));
+                                    if(stack.getCount() == 1) {
+                                        stack.grow(productivity);
+                                    }
+                                    else {
+                                        float modifier = (1f / (productivity + 2f) + (productivity + 1f) / 2f) * stack.getCount();
+                                        stack.grow(Math.round(modifier));
+                                    }
                                 }
                             }
-
                             // Apply upgrades
                             int normalProductivityUpgrades = getUpgradeCount(ModItems.UPGRADE_PRODUCTIVITY.get());
                             int highEndProductivityUpgrades = getUpgradeCount(ModItems.UPGRADE_HIGH_END_PRODUCTIVITY.get());


### PR DESCRIPTION
closes #392 
With an `if-statement` the productivity trait now correctly influences the amount of combs. If bees with a base output of more than 1 comb get re-added into the mod, the same formula as before will apply.

The following outputs now apply for bees with a base output of 1 (without any productivity upgrades):
```
normal --> 1
medium --> 2
high --> 3
very high --> 4
```