### PR TITLE
fix English JEI tooltip for centrifuge chance drops

### DIFF
--- a/src/main/resources/assets/productivebees/lang/en_us.json
+++ b/src/main/resources/assets/productivebees/lang/en_us.json
@@ -807,7 +807,7 @@
   "jei.productivebees.centrifuge": "Centrifuge",
   "jei.productivebees.incubation": "Incubation",
   "productivebees.centrifuge.tooltip.amount": "Amount: %s",
-  "productivebees.centrifuge.tooltip.chance": "Chance: %s%%",
+  "productivebees.centrifuge.tooltip.chance": "Chance: %s",
   "productivebees.incubator.tooltip.treat_item": "Here goes honey treats",
   "productivebees.advanced_hive.tooltip.bee_cage": "Put empty bee cages to pull out bees or filled bee cages to insert bees",
   "productivebees.heated_centrifuge.tooltip": "\"It's ruining the honey\" - some vegan",


### PR DESCRIPTION
All other languages don't add the '%' in the translation string. The code in
 * compat/jei/CentrifugeRecipeCategory.java
 * compat/jei/AdvancedBeehiveRecipeCategory.java

does that already, so English would display a second '%'.

![tooltip](https://github.com/JDKDigital/productive-bees/assets/28407460/82182148-f9b3-4031-babc-468ae6bf6133)
