### PR TITLE
Fix newline rendered as "LF" in book.

### DIFF
--- a/src/main/resources/assets/productivebees/patchouli_books/guide/en_us/entries/blocks/gene_indexer.json
+++ b/src/main/resources/assets/productivebees/patchouli_books/guide/en_us/entries/blocks/gene_indexer.json
@@ -10,7 +10,7 @@
         },
         {
             "type": "patchouli:text",
-            "text": "Fill up this extra big container with all the genes you have lying around, flip a switch and watch as the automated internal gene indexer thingy combines the genes for you. It might not be the most efficient way...but it's automated!\nNeeds a redstone signal."
+            "text": "Fill up this extra big container with all the genes you have lying around, flip a switch and watch as the automated internal gene indexer thingy combines the genes for you. It might not be the most efficient way...but it's automated!$(br2)Needs a redstone signal."
         }
     ]
 }


### PR DESCRIPTION
Previously, the newline in the page on the "Gene Indexer" was rendered as the text "LF" rather than properly creating a break in the text.

There was zero testing done on this change, and I don't intend to do anything more if there are additional considerations before it can be merged. I copied the line break sequence, `$(br2)`, from the bottler text. I hope that works as I assume it does. 

The following image is how it appears for me in ATM9:

![image](https://github.com/JDKDigital/productive-bees/assets/2153080/64603a12-8b09-4ddc-ad44-258c03797697)

*Thanks for the mod. I'm just starting, but it has a nostalgia factor from the bees in FTB Ultimate several years ago.*