### PR TITLE
Entro crystal bee addition

### DIFF
--- a/src/generated/resources/data/productivebees/productivebees/extendedae/entro.json
+++ b/src/generated/resources/data/productivebees/productivebees/extendedae/entro.json
@@ -1,0 +1,15 @@
+{
+    "primaryColor": "#55eb34",
+    "secondaryColor": "#34eb58",
+    "particleColor": "#55eb34",
+    "description": "Entro crystal automation!",
+    "flowerItem": "extendedae:entro_block",
+    "createComb": true,
+    "renderer": "default_crystal",
+    "conditions": [
+      {
+        "modid": "extendedae",
+        "type": "neoforge:mod_loaded"
+      }
+    ]
+  } 


### PR DESCRIPTION
made a custom entro crystal bee for my pack with how heavy i'm making the resource in it and thought it might fit in the base mod.

i do also have the bee converison & comb recipes made but i couldn't find where those would go in the git as it seemed it wasnt in the data/productivebees/recipes folder