### PR TITLE
Fix Production Upgrades

### DIFF
--- a/src/main/java/cy/jdkdigital/productivebees/common/block/entity/AdvancedBeehiveBlockEntity.java
+++ b/src/main/java/cy/jdkdigital/productivebees/common/block/entity/AdvancedBeehiveBlockEntity.java
@@ -252,7 +252,7 @@ public class AdvancedBeehiveBlockEntity extends AdvancedBeehiveBlockEntityAbstra
             if (!(beeEntity instanceof ProductiveBee productiveBee) || !productiveBee.hasConverted()) {
                 getCapability(ForgeCapabilities.ITEM_HANDLER).ifPresent(inv -> {
                     // Count productivity modifier
-                    double upgradeMod = ProductiveBeesConfig.UPGRADES.productivityMultiplier.get() * getUpgradeCount(ModItems.UPGRADE_PRODUCTIVITY.get())
+                    double upgradeMod = 1 + ProductiveBeesConfig.UPGRADES.productivityMultiplier.get() * getUpgradeCount(ModItems.UPGRADE_PRODUCTIVITY.get())
                                         + ProductiveBeesConfig.UPGRADES.productivityMultiplier2.get() * getUpgradeCount(ModItems.UPGRADE_PRODUCTIVITY_2.get())
                                         + ProductiveBeesConfig.UPGRADES.productivityMultiplier3.get() * getUpgradeCount(ModItems.UPGRADE_PRODUCTIVITY_3.get())
                                         + ProductiveBeesConfig.UPGRADES.productivityMultiplier4.get() * getUpgradeCount(ModItems.UPGRADE_PRODUCTIVITY_4.get());

--- a/src/main/java/cy/jdkdigital/productivebees/util/BeeHelper.java
+++ b/src/main/java/cy/jdkdigital/productivebees/util/BeeHelper.java
@@ -309,7 +309,7 @@ public class BeeHelper
             }
         }
 
-        int rolls = Math.max(1, (int) modifier);
+        int rolls = (int) Math.floor(modifier) + (level.random.nextDouble() < modifier % 1 ? 1 : 0);
 
         if (matchedRecipe != null) {
             matchedRecipe.getRecipeOutputs().forEach((itemStack, bounds) -> {


### PR DESCRIPTION
Fixes #537 
Added 1 to upgradeMod. This means hives now have a base productivity so putting any single upgrade in doesnt replace the 100% but gets added to it (so putting in one alpha now adds 120% instead of just 20% like any additional upgrade does)

Changed the bee produce recipe rolls to average out on the actual upgradeMod instead of  just the truncated upgradeMod. This means that if you put in one alpha upgrade you get an 80% chance of 2 rolls and a 20% chance of 3 rolls, averaging out at 2.2 (-> 100% from the hive + 120% from the upgrade)

Based off of the upgrade descriptions this is what should be happening, at least from my understanding