### PR TITLE
fix: copy stack from ingredient before modifying it

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,7 +143,7 @@ dependencies {
     compileOnly "dev.emi:emi-neoforge:${emi_version}:api"
     runtimeOnly "dev.emi:emi-neoforge:${emi_version}"
 
-    compileOnly "com.almostreliable.mods:almostunified-neoforge:1.21-1.0.0:api"
+    compileOnly "com.almostreliable.mods:almostunified-neoforge:1.21.1-1.0.0:api"
 
     compileOnly "vazkii.patchouli:Patchouli:${patchouli_version}:api"
     runtimeOnly "vazkii.patchouli:Patchouli:${patchouli_version}"

--- a/src/main/java/cy/jdkdigital/productivebees/common/entity/bee/ProductiveBee.java
+++ b/src/main/java/cy/jdkdigital/productivebees/common/entity/bee/ProductiveBee.java
@@ -217,9 +217,7 @@ public class ProductiveBee extends Bee implements IProductiveBee
 
     public List<ItemStack> getBreedingItems() {
         int count = getBreedingItemCount();
-        List<ItemStack> list = Arrays.stream(getBreedingIngredient().getItems()).toList();
-        list.forEach(e -> e.setCount(count));
-        return list;
+        return Arrays.stream(getBreedingIngredient().getItems()).map(itemStack -> itemStack.copyWithCount(count)).toList();
     }
 
     @Override


### PR DESCRIPTION
Hello, I'm making this PR to this mod to add compatibility to a feature (Ingredient Deduplication) on my mod that relies heavily on modders to not modify the inner stack of those ingredients.

I would greatly appreciate it if you could accept this PR.

Thanks.
