### PR TITLE
Change Breeding Chamber Block bee slot size

### DIFF
--- a/src/main/java/cy/jdkdigital/productivebees/common/block/entity/BreedingChamberBlockEntity.java
+++ b/src/main/java/cy/jdkdigital/productivebees/common/block/entity/BreedingChamberBlockEntity.java
@@ -84,6 +84,15 @@ public class BreedingChamberBlockEntity extends CapabilityBlockEntity implements
                 }
             }
         }
+        
+        @Override
+        public int getSlotLimit(int slot) {
+            if (slot == BreedingChamberContainer.SLOT_BEE_1 || slot == BreedingChamberContainer.SLOT_BEE_2) {
+                // for conduit input and automation
+                return 1;
+            }
+            return super.getSlotLimit(slot);
+        }
     });
 
     protected LazyOptional<IItemHandlerModifiable> upgradeHandler = LazyOptional.of(() -> new InventoryHandlerHelper.UpgradeHandler(4, this));


### PR DESCRIPTION
On the automated production line, the slot size is too large, and the input of the conduit will exceed one, but I think parents should only allow one to exist
![image](https://github.com/user-attachments/assets/0b2bb359-9d8a-4756-8c9f-85c0e9551055)
