### PR TITLE
fix(jei): use component ingredient to generate stacks with components

### DIFF
--- a/src/main/java/cy/jdkdigital/productivebees/compat/jei/ProductiveBeesJeiPlugin.java
+++ b/src/main/java/cy/jdkdigital/productivebees/compat/jei/ProductiveBeesJeiPlugin.java
@@ -322,14 +322,14 @@ public class ProductiveBeesJeiPlugin implements IModPlugin
             BeeCreator.setType(beeType, comb);
             NonNullList<Ingredient> combInput = NonNullList.create();
             for (int i = 0; i < count; i++) {
-                combInput.add(Ingredient.of(comb));
+                combInput.add(DataComponentIngredient.of(false, comb));
             }
 
             // Add comb block
             ItemStack combBlock = new ItemStack(ModItems.CONFIGURABLE_COMB_BLOCK.get());
             BeeCreator.setType(beeType, combBlock);
             NonNullList<Ingredient> combBlockInput = NonNullList.create();
-            combBlockInput.add(Ingredient.of(combBlock));
+            combBlockInput.add(DataComponentIngredient.of(false, combBlock));
 
             recipes.add(new RecipeHolder<>(idComb, new ShapelessRecipe("", CraftingBookCategory.BUILDING, combBlock, combInput)));
             ItemStack combOutput = comb.copy();


### PR DESCRIPTION
Hello 👋 , I'm making this PR to this mod to add compatibility to a feature (Ingredient Deduplication) on my mod (AllTheLeaks) that relies heavily on modders to precisely use ingredients that accurately generates the desired itemstack.

I would greatly appreciate it if you could accept this PR.

Thanks.