### PR TITLE
Display Configurable Comb Block names with WAILA likes

### DIFF
--- a/src/main/java/cy/jdkdigital/productivebees/compat/hwyla/BeeEntityElement.java
+++ b/src/main/java/cy/jdkdigital/productivebees/compat/hwyla/BeeEntityElement.java
@@ -1,0 +1,41 @@
+package cy.jdkdigital.productivebees.compat.hwyla;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.util.Mth;
+import net.minecraft.world.phys.Vec2;
+
+import cy.jdkdigital.productivebees.client.render.ingredient.BeeRenderer;
+import cy.jdkdigital.productivebees.compat.jei.ingredients.BeeIngredient;
+import snownee.jade.api.ui.Element;
+
+public class BeeEntityElement extends Element {
+
+    private final BeeIngredient bee;
+    private final float scale;
+
+    private BeeEntityElement(BeeIngredient bee, float scale) {
+        this.bee = bee;
+        this.scale = scale == 0 ? 1 : scale;
+    }
+
+    public static BeeEntityElement of(BeeIngredient bee) {
+        return of(bee, 1);
+    }
+
+    public static BeeEntityElement of(BeeIngredient bee, float scale) {
+        return new BeeEntityElement(bee, scale);
+    }
+
+    @Override
+    public Vec2 getSize() {
+        int size = Mth.floor(18 * scale);
+        return new Vec2(size, size);
+    }
+
+    @Override
+    public void render(GuiGraphics guiGraphics, float x, float y, float maxX, float maxY) {
+        Minecraft mc = Minecraft.getInstance();
+        BeeRenderer.render(guiGraphics, (int) x + 1, (int) y + 1, this.bee, mc);
+    }
+}

--- a/src/main/java/cy/jdkdigital/productivebees/compat/hwyla/BeeNestProvider.java
+++ b/src/main/java/cy/jdkdigital/productivebees/compat/hwyla/BeeNestProvider.java
@@ -1,0 +1,105 @@
+package cy.jdkdigital.productivebees.compat.hwyla;
+
+import cy.jdkdigital.productivebees.ProductiveBees;
+import cy.jdkdigital.productivebees.common.block.entity.AdvancedBeehiveBlockEntityAbstract;
+import cy.jdkdigital.productivebees.common.entity.bee.ProductiveBee;
+import cy.jdkdigital.productivebees.compat.jei.ingredients.BeeIngredient;
+import cy.jdkdigital.productivebees.compat.jei.ingredients.BeeIngredientFactory;
+import cy.jdkdigital.productivebees.handler.bee.CapabilityBee;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.phys.Vec2;
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.IServerDataProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.config.IPluginConfig;
+import snownee.jade.api.ui.IElement;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class BeeNestProvider implements IBlockComponentProvider, IServerDataProvider<BlockAccessor> {
+    static final BeeNestProvider INSTANCE = new BeeNestProvider();
+    public static final ResourceLocation UID = new ResourceLocation(ProductiveBees.MODID, "bee_nest");
+
+
+    @Override
+    public void appendTooltip(ITooltip tooltip, BlockAccessor blockAccessor, IPluginConfig iPluginConfig) {
+        var be = blockAccessor.getBlockEntity();
+        if (be == null) return;
+        if (be instanceof AdvancedBeehiveBlockEntityAbstract tileEntity) {
+            tileEntity.loadPacketNBT(blockAccessor.getServerData());
+            List<AdvancedBeehiveBlockEntityAbstract.Inhabitant> bees = tileEntity.getBeeList();
+
+
+            Map<String, Integer> beeCounts = new HashMap<>();
+            Map<String, IElement> beeElements = new HashMap<>();
+
+            if (!bees.isEmpty()) {
+
+                for (AdvancedBeehiveBlockEntityAbstract.Inhabitant bee : bees) {
+                    if (beeCounts.containsKey(bee.localizedName)) {
+                        beeCounts.put(bee.localizedName, beeCounts.get(bee.localizedName) + 1);
+                    } else {
+                        beeCounts.put(bee.localizedName, 1);
+                    }
+
+                    if (!beeElements.containsKey(bee.localizedName)) {
+                        CompoundTag entityData = bee.nbt.copy();
+                        String type = entityData.getString("type");
+                        if (type.isEmpty()) {
+                            type = entityData.getString("id");
+                        }
+                        BeeIngredient beeIngredient = BeeIngredientFactory.getIngredient(type).get();
+                        Entity beeEntity = beeIngredient.getCachedEntity(be.getLevel());
+                        float scaledSize = 18.0F;
+                        float offset = -3.0F;
+                        if (beeEntity instanceof ProductiveBee pBee) {
+                            if (pBee.getSizeModifier() >= 4.0F) {
+                                offset = -1.0F;
+                            } else {
+                                scaledSize = scaledSize * pBee.getSizeModifier();
+                                offset = offset - 18.0F / scaledSize;
+                            }
+                        }
+                        IElement beeIcon = BeeEntityElement.of(beeIngredient, scaledSize / 18.0F).size(new Vec2(16, 16))
+                                .translate(new Vec2(0, offset));
+                        beeElements.put(bee.localizedName, beeIcon);
+                    }
+                }
+            }
+            if (!beeCounts.isEmpty()) {
+                beeCounts.forEach((name, count) -> {
+                    tooltip.add(beeElements.get(name));
+                    MutableComponent text = Component.literal(count.toString())
+                            .append(Component.literal("x "));
+                    tooltip.append(text.append(Component.translatable(name)));
+                });
+            }
+        }
+
+
+    }
+
+    @Override
+    public void appendServerData(CompoundTag compoundTag, BlockAccessor accessor) {
+        BlockEntity be = accessor.getBlockEntity();
+        if (be != null) {
+            var cap = be.getCapability(CapabilityBee.BEE).resolve().orElse(null);
+            if (cap != null && cap.countInhabitants() > 0 && be instanceof AdvancedBeehiveBlockEntityAbstract nest) {
+                nest.savePacketNBT(compoundTag);
+            }
+        }
+    }
+
+    @Override
+    public ResourceLocation getUid() {
+        return UID;
+    }
+}

--- a/src/main/java/cy/jdkdigital/productivebees/compat/hwyla/ConfigurableCombProvider.java
+++ b/src/main/java/cy/jdkdigital/productivebees/compat/hwyla/ConfigurableCombProvider.java
@@ -1,0 +1,41 @@
+package cy.jdkdigital.productivebees.compat.hwyla;
+
+import cy.jdkdigital.productivebees.ProductiveBees;
+import cy.jdkdigital.productivebees.common.block.entity.CombBlockBlockEntity;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.config.IPluginConfig;
+
+public class ConfigurableCombProvider implements IBlockComponentProvider {
+    static final ConfigurableCombProvider INSTANCE = new ConfigurableCombProvider();
+    public static final ResourceLocation UID = new ResourceLocation(ProductiveBees.MODID, "configurable_comb");
+
+    @Override
+    public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
+        if (!(accessor.getBlockEntity() instanceof CombBlockBlockEntity tileEntity)) {
+            return;
+        }
+        tooltip.clear();
+        tooltip.add(getName(tileEntity.getCombType()));
+
+    }
+
+    @Override
+    public ResourceLocation getUid() {
+        return UID;
+    }
+
+    private Component getName(String type) {
+        if (type != null && !type.isEmpty()) {
+
+            String name = Component.translatable("entity.productivebees." + type.split(":")[1] + "_bee").getString();
+            return Component.translatable("block.productivebees.comb_configurable", name.replace(" Bee", "")).withStyle(ChatFormatting.WHITE);
+
+        }
+        return Component.translatable("block.productivebees.comb_configurable").withStyle(ChatFormatting.WHITE);
+    }
+}

--- a/src/main/java/cy/jdkdigital/productivebees/compat/hwyla/ProductiveBeesWailaPlugin.java
+++ b/src/main/java/cy/jdkdigital/productivebees/compat/hwyla/ProductiveBeesWailaPlugin.java
@@ -1,10 +1,7 @@
 package cy.jdkdigital.productivebees.compat.hwyla;
 
 import cy.jdkdigital.productivebees.ProductiveBees;
-import cy.jdkdigital.productivebees.common.block.CanvasBeehive;
-import cy.jdkdigital.productivebees.common.block.CanvasExpansionBox;
-import cy.jdkdigital.productivebees.common.block.Jar;
-import cy.jdkdigital.productivebees.common.block.SolitaryNest;
+import cy.jdkdigital.productivebees.common.block.*;
 import cy.jdkdigital.productivebees.common.block.entity.JarBlockEntity;
 import cy.jdkdigital.productivebees.common.block.entity.SolitaryNestBlockEntity;
 import cy.jdkdigital.productivebees.common.entity.bee.ProductiveBee;
@@ -32,6 +29,7 @@ public class ProductiveBeesWailaPlugin implements IWailaPlugin
         registration.registerBlockComponent(CanvasExpansionBoxProvider.INSTANCE, CanvasExpansionBox.class);
         registration.registerBlockComponent(SolitaryNestProvider.INSTANCE, SolitaryNest.class);
         registration.registerBlockComponent(JarProvider.INSTANCE, Jar.class);
+        registration.registerBlockComponent(ConfigurableCombProvider.INSTANCE, ConfigurableCombBlock.class);
         registration.registerEntityComponent(ProductiveBeeProvider.INSTANCE, ProductiveBee.class);
         registration.addConfig(BEE_ATTRIBUTES, true);
     }

--- a/src/main/java/cy/jdkdigital/productivebees/compat/hwyla/ProductiveBeesWailaPlugin.java
+++ b/src/main/java/cy/jdkdigital/productivebees/compat/hwyla/ProductiveBeesWailaPlugin.java
@@ -2,6 +2,7 @@ package cy.jdkdigital.productivebees.compat.hwyla;
 
 import cy.jdkdigital.productivebees.ProductiveBees;
 import cy.jdkdigital.productivebees.common.block.*;
+import cy.jdkdigital.productivebees.common.block.entity.AdvancedBeehiveBlockEntityAbstract;
 import cy.jdkdigital.productivebees.common.block.entity.JarBlockEntity;
 import cy.jdkdigital.productivebees.common.block.entity.SolitaryNestBlockEntity;
 import cy.jdkdigital.productivebees.common.entity.bee.ProductiveBee;
@@ -20,6 +21,7 @@ public class ProductiveBeesWailaPlugin implements IWailaPlugin
     public void register(IWailaCommonRegistration registration) {
         registration.registerBlockDataProvider(SolitaryNestProvider.INSTANCE, SolitaryNestBlockEntity.class);
         registration.registerBlockDataProvider(JarProvider.INSTANCE, JarBlockEntity.class);
+        registration.registerBlockDataProvider(BeeNestProvider.INSTANCE, AdvancedBeehiveBlockEntityAbstract.class);
         registration.registerEntityDataProvider(ProductiveBeeProvider.INSTANCE, ProductiveBee.class);
     }
 
@@ -29,6 +31,7 @@ public class ProductiveBeesWailaPlugin implements IWailaPlugin
         registration.registerBlockComponent(CanvasExpansionBoxProvider.INSTANCE, CanvasExpansionBox.class);
         registration.registerBlockComponent(SolitaryNestProvider.INSTANCE, SolitaryNest.class);
         registration.registerBlockComponent(JarProvider.INSTANCE, Jar.class);
+        registration.registerBlockComponent(BeeNestProvider.INSTANCE, AdvancedBeehive.class);
         registration.registerBlockComponent(ConfigurableCombProvider.INSTANCE, ConfigurableCombBlock.class);
         registration.registerEntityComponent(ProductiveBeeProvider.INSTANCE, ProductiveBee.class);
         registration.addConfig(BEE_ATTRIBUTES, true);

--- a/src/main/java/cy/jdkdigital/productivebees/compat/top/TopPlugin.java
+++ b/src/main/java/cy/jdkdigital/productivebees/compat/top/TopPlugin.java
@@ -81,6 +81,18 @@ public class TopPlugin implements Function<ITheOneProbe, Void>
                 return true;
             }
 
+            // Configurable Comb Block
+            if (tileEntity instanceof CombBlockBlockEntity combBlock) {
+                String type = combBlock.getCombType();
+                String name = Component.translatable("entity.productivebees." + type.split(":")[1] + "_bee").getString();
+                probeInfo.horizontal()
+                        .item(new ItemStack(blockState.getBlock().asItem()))
+                        .vertical()
+                        .text(Component.translatable("block.productivebees.comb_configurable", name.replace(" Bee", "")))
+                        .text(CompoundText.create().style(TextStyleClass.MODNAME).text("Productive Bees"));
+                return true;
+            }
+
             // Canvas hive and expansionbox
             if (tileEntity instanceof CanvasBeehiveBlockEntity || tileEntity instanceof CanvasExpansionBoxBlockEntity) {
                 String style = blockState.getBlock().getDescriptionId().replace("block.productivebees.advanced_", "").replace("_canvas_beehive", "");

--- a/src/main/resources/assets/productivebees/lang/en_us.json
+++ b/src/main/resources/assets/productivebees/lang/en_us.json
@@ -1021,6 +1021,7 @@
   "config.jade.plugin_productivebees.canvas_beehive": "Canvas Beehive",
   "config.jade.plugin_productivebees.canvas_expansion_box": "Canvas Expansion Box",
   "config.jade.plugin_productivebees.configurable_comb": "Configurable Comb",
+  "config.jade.plugin_productivebees.bee_nest": "Bee Nest",
   "productivebees.top.jar.bee": "%s",
 
   "tag.item.productivebees.advanced_beehives": "Advanced Beehives",

--- a/src/main/resources/assets/productivebees/lang/en_us.json
+++ b/src/main/resources/assets/productivebees/lang/en_us.json
@@ -1020,6 +1020,7 @@
   "config.jade.plugin_productivebees.bee_attributes": "Attributes",
   "config.jade.plugin_productivebees.canvas_beehive": "Canvas Beehive",
   "config.jade.plugin_productivebees.canvas_expansion_box": "Canvas Expansion Box",
+  "config.jade.plugin_productivebees.configurable_comb": "Configurable Comb",
   "productivebees.top.jar.bee": "%s",
 
   "tag.item.productivebees.advanced_beehives": "Advanced Beehives",


### PR DESCRIPTION
When you place a configurable comb block in world, Jade/TOP don't tell you what kind it is. Instead they both display the block as "Comb Block". These changes give Jade and TOP the info they need to display the correct configurable comb block name.