### PR TITLE
Add codec to JEI bee ingredient registration.

### DIFF
--- a/src/main/java/cy/jdkdigital/productivebees/compat/jei/ProductiveBeesJeiPlugin.java
+++ b/src/main/java/cy/jdkdigital/productivebees/compat/jei/ProductiveBeesJeiPlugin.java
@@ -1,5 +1,8 @@
 package cy.jdkdigital.productivebees.compat.jei;
 
+import com.google.common.base.Suppliers;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
 import cy.jdkdigital.productivebees.ProductiveBees;
 import cy.jdkdigital.productivebees.client.helper.RecipeHelper;
 import cy.jdkdigital.productivebees.common.crafting.ingredient.BeeIngredient;
@@ -47,6 +50,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.Nonnull;
 import java.util.*;
+import java.util.function.Supplier;
 
 @JeiPlugin
 public class ProductiveBeesJeiPlugin implements IModPlugin
@@ -114,7 +118,8 @@ public class ProductiveBeesJeiPlugin implements IModPlugin
     @Override
     public void registerIngredients(IModIngredientRegistration registration) {
         Collection<BeeIngredient> ingredients = BeeIngredientFactory.getOrCreateList(true).values();
-        registration.register(BEE_INGREDIENT, new ArrayList<>(ingredients), new BeeIngredientHelper(), new BeeIngredientRenderer());
+        Codec<BeeIngredient> codec = BeeIngredient.CODEC.comapFlatMap((supplier) -> DataResult.success(supplier.get()), Suppliers::ofInstance);
+        registration.register(BEE_INGREDIENT, new ArrayList<>(ingredients), new BeeIngredientHelper(), new BeeIngredientRenderer(), codec);
     }
 
     @Override


### PR DESCRIPTION
With the latest version of JEI (19.24.0.317), there is a non-fatal error registering the bee ingredients causing the bees to not show in JEI. This is caused by JEI requiring a non-null codec to be passed when registering the ingredients. By adding a derivative of `BeeIngredient.CODEC` (since that is a `Codec<Supplier<BeeIngredient>>` and a `Codec<BeeIngredient>` needs to be passed in), the bees register and display properly.