### PR TITLE
Fix startup hang by deferring config reads to render time

### DIFF
--- a/src/main/java/cy/jdkdigital/productivebees/ProductiveBeesConfig.java
+++ b/src/main/java/cy/jdkdigital/productivebees/ProductiveBeesConfig.java
@@ -31,6 +31,7 @@ public class ProductiveBeesConfig
         public final ModConfigSpec.BooleanValue alwaysChristmas;
         public final ModConfigSpec.BooleanValue neverChristmas;
         public final ModConfigSpec.BooleanValue renderEntitiesInAmber;
+        public final ModConfigSpec.BooleanValue enableAprilFoolRendering;
 
         public Client(ModConfigSpec.Builder builder) {
             builder.push("Client");
@@ -58,6 +59,10 @@ public class ProductiveBeesConfig
             renderEntitiesInAmber = builder
                     .comment("Render entities inside amber blocks.")
                     .define("renderEntitiesInAmber", true);
+
+            enableAprilFoolRendering = builder
+                    .comment("Enable april fools rendering effects (flipped bees).")
+                    .define("enableAprilFoolRendering", true);
 
             builder.pop();
         }

--- a/src/main/java/cy/jdkdigital/productivebees/client/render/entity/DyeBeeRenderer.java
+++ b/src/main/java/cy/jdkdigital/productivebees/client/render/entity/DyeBeeRenderer.java
@@ -14,7 +14,7 @@ public class DyeBeeRenderer extends ProductiveBeeRenderer
     public DyeBeeRenderer(EntityRendererProvider.Context context) {
         super(context, new ProductiveBeeModel<>(context.bakeLayer(PB_MAIN_LAYER), "default"));
 
-        addLayer(new BeeBodyLayer(this, context.bakeLayer(PB_DEFAULT_LAYER), "default", isChristmas));
+        addLayer(new BeeBodyLayer(this, context.bakeLayer(PB_DEFAULT_LAYER), "default"));
     }
 
     @Nonnull

--- a/src/main/java/cy/jdkdigital/productivebees/client/render/entity/ProductiveBeeRenderer.java
+++ b/src/main/java/cy/jdkdigital/productivebees/client/render/entity/ProductiveBeeRenderer.java
@@ -39,41 +39,56 @@ public class ProductiveBeeRenderer extends MobRenderer<ProductiveBee, Productive
     public static final ModelLayerLocation PB_TINY_LAYER = new ModelLayerLocation(ResourceLocation.fromNamespaceAndPath(ProductiveBees.MODID, "tiny"), "main");
     public static final ModelLayerLocation PB_SLIMY_LAYER = new ModelLayerLocation(ResourceLocation.fromNamespaceAndPath(ProductiveBees.MODID, "translucent_with_center"), "main");
 
-    protected boolean isChristmas;
-    protected boolean isAprilFool;
-
     public ProductiveBeeRenderer(EntityRendererProvider.Context context) {
         this(context, new ProductiveBeeModel<>(context.bakeLayer(PB_MAIN_LAYER)));
 
-        addLayer(new BeeBodyLayer(this, context.bakeLayer(PB_THICC_LAYER), "thicc", isChristmas));
-        addLayer(new BeeBodyLayer(this, context.bakeLayer(PB_DEFAULT_LAYER), "default", isChristmas));
-        addLayer(new BeeBodyLayer(this, context.bakeLayer(PB_DEFAULT_CRYSTAL_LAYER), "default_crystal", isChristmas));
-        addLayer(new BeeBodyLayer(this, context.bakeLayer(PB_DEFAULT_SHELL_LAYER), "default_shell", isChristmas));
-        addLayer(new BeeBodyLayer(this, context.bakeLayer(PB_DEFAULT_FOLIAGE_LAYER), "default_foliage", isChristmas));
-        addLayer(new BeeBodyLayer(this, context.bakeLayer(PB_ELVIS_LAYER), "elvis", isChristmas));
-        addLayer(new BeeBodyLayer(this, context.bakeLayer(PB_SMALL_LAYER), "small", isChristmas));
-        addLayer(new BeeBodyLayer(this, context.bakeLayer(PB_SLIM_LAYER), "slim", isChristmas));
-        addLayer(new BeeBodyLayer(this, context.bakeLayer(PB_TINY_LAYER), "tiny", isChristmas));
-        addLayer(new BeeBodyLayer(this, context.bakeLayer(PB_SLIMY_LAYER), "translucent_with_center", isChristmas));
+        addLayer(new BeeBodyLayer(this, context.bakeLayer(PB_THICC_LAYER), "thicc"));
+        addLayer(new BeeBodyLayer(this, context.bakeLayer(PB_DEFAULT_LAYER), "default"));
+        addLayer(new BeeBodyLayer(this, context.bakeLayer(PB_DEFAULT_CRYSTAL_LAYER), "default_crystal"));
+        addLayer(new BeeBodyLayer(this, context.bakeLayer(PB_DEFAULT_SHELL_LAYER), "default_shell"));
+        addLayer(new BeeBodyLayer(this, context.bakeLayer(PB_DEFAULT_FOLIAGE_LAYER), "default_foliage"));
+        addLayer(new BeeBodyLayer(this, context.bakeLayer(PB_ELVIS_LAYER), "elvis"));
+        addLayer(new BeeBodyLayer(this, context.bakeLayer(PB_SMALL_LAYER), "small"));
+        addLayer(new BeeBodyLayer(this, context.bakeLayer(PB_SLIM_LAYER), "slim"));
+        addLayer(new BeeBodyLayer(this, context.bakeLayer(PB_TINY_LAYER), "tiny"));
+        addLayer(new BeeBodyLayer(this, context.bakeLayer(PB_SLIMY_LAYER), "translucent_with_center"));
     }
+
+    private static boolean cachedIsChristmas;
+    private static boolean cachedIsAprilFool;
+    private static long lastCacheUpdate;
 
     public ProductiveBeeRenderer(EntityRendererProvider.Context context, ProductiveBeeModel<ProductiveBee> model) {
         super(context, model, 0.4F);
+    }
 
+    private static void updateCache() {
+        long now = System.currentTimeMillis();
+        if (now - lastCacheUpdate < 60_000) {
+            return;
+        }
+        lastCacheUpdate = now;
         Calendar calendar = Calendar.getInstance();
-        if (ProductiveBeesConfig.CLIENT.alwaysChristmas.get() || (calendar.get(Calendar.MONTH) + 1 == 12 && calendar.get(Calendar.DATE) >= 21 && calendar.get(Calendar.DATE) <= 26)) {
-            this.isChristmas = !ProductiveBeesConfig.CLIENT.neverChristmas.get();
-        }
-        if (calendar.get(Calendar.MONTH) + 1 == 4 && calendar.get(Calendar.DATE) <= 1) {
-            this.isAprilFool = ProductiveBeesConfig.GENERAL.enableJokes.get();
-        }
+        boolean isChristmasSeason = calendar.get(Calendar.MONTH) + 1 == 12 && calendar.get(Calendar.DATE) >= 21 && calendar.get(Calendar.DATE) <= 26;
+        cachedIsChristmas = (ProductiveBeesConfig.CLIENT.alwaysChristmas.get() || isChristmasSeason) && !ProductiveBeesConfig.CLIENT.neverChristmas.get();
+        cachedIsAprilFool = (calendar.get(Calendar.MONTH) + 1 == 4 && calendar.get(Calendar.DATE) <= 1) && ProductiveBeesConfig.CLIENT.enableAprilFoolRendering.get();
+    }
+
+    public static boolean isChristmas() {
+        updateCache();
+        return cachedIsChristmas;
+    }
+
+    public static boolean isAprilFool() {
+        updateCache();
+        return cachedIsAprilFool;
     }
 
     @Override
     protected void setupRotations(ProductiveBee pEntity, PoseStack pPoseStack, float pBob, float pYBodyRot, float pPartialTick, float pScale) {
         super.setupRotations(pEntity, pPoseStack, pBob, pYBodyRot, pPartialTick, pScale);
 
-        if (isAprilFool || (pEntity instanceof ConfigurableBee configurableBee && configurableBee.getRenderTransform().equals("flipped"))) {
+        if (isAprilFool() || (pEntity instanceof ConfigurableBee configurableBee && configurableBee.getRenderTransform().equals("flipped"))) {
             pPoseStack.translate(0.0D, pEntity.getBbHeight() + 0.1F, 0.0D);
             pPoseStack.mulPose(Axis.ZP.rotationDegrees(180.0F));
         }

--- a/src/main/java/cy/jdkdigital/productivebees/client/render/entity/layers/BeeBodyLayer.java
+++ b/src/main/java/cy/jdkdigital/productivebees/client/render/entity/layers/BeeBodyLayer.java
@@ -26,7 +26,6 @@ public class BeeBodyLayer extends RenderLayer<ProductiveBee, ProductiveBeeModel<
 {
     private final String modelType;
     private final EntityModel<ProductiveBee> model;
-    private final boolean isChristmas;
 
     public static Map<String, Map<String, ResourceLocation>> baseTextures = new HashMap<>() {{
         put("default", new HashMap<>() {{
@@ -67,12 +66,11 @@ public class BeeBodyLayer extends RenderLayer<ProductiveBee, ProductiveBeeModel<
         }});
     }};
 
-    public BeeBodyLayer(RenderLayerParent<ProductiveBee, ProductiveBeeModel<ProductiveBee>> rendererIn, ModelPart layer, String modelType, boolean isChristmas) {
+    public BeeBodyLayer(RenderLayerParent<ProductiveBee, ProductiveBeeModel<ProductiveBee>> rendererIn, ModelPart layer, String modelType) {
         super(rendererIn);
 
         this.modelType = modelType;
         model = new ProductiveBeeModel<>(layer, modelType);
-        this.isChristmas = isChristmas;
     }
 
     public void render(@Nonnull PoseStack matrixStackIn, @Nonnull MultiBufferSource bufferIn, int packedLightIn, @Nonnull ProductiveBee entity, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch) {
@@ -161,7 +159,7 @@ public class BeeBodyLayer extends RenderLayer<ProductiveBee, ProductiveBeeModel<
     }
 
     private void renderChristmasHat(@Nonnull PoseStack matrixStackIn, @Nonnull MultiBufferSource bufferIn, int packedLightIn, @Nonnull ProductiveBee entity) {
-        if (isChristmas && !entity.getRenderStatic() && this.modelType.contains("default")) {
+        if (ProductiveBeeRenderer.isChristmas() && !entity.getRenderStatic() && this.modelType.contains("default")) {
             ResourceLocation location = ProductiveBeeRenderer.resLoc(ProductiveBees.MODID + ":textures/entity/bee/base/" + this.modelType + "/santa_hat.png");
             renderColoredCutoutModel(this.model, location, matrixStackIn, bufferIn, packedLightIn, entity, -1);
         }

--- a/src/main/java/cy/jdkdigital/productivebees/compat/geckolib/client/render/GeckoBeeRenderer.java
+++ b/src/main/java/cy/jdkdigital/productivebees/compat/geckolib/client/render/GeckoBeeRenderer.java
@@ -3,7 +3,7 @@ package cy.jdkdigital.productivebees.compat.geckolib.client.render;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.math.Axis;
-import cy.jdkdigital.productivebees.ProductiveBeesConfig;
+import cy.jdkdigital.productivebees.client.render.entity.ProductiveBeeRenderer;
 import cy.jdkdigital.productivebees.client.render.entity.layers.BeeBodyLayer;
 import cy.jdkdigital.productivebees.common.entity.bee.GeckoBee;
 import cy.jdkdigital.productivebees.compat.geckolib.client.render.model.GeckoBeeModel;
@@ -16,37 +16,24 @@ import software.bernie.geckolib.renderer.GeoEntityRenderer;
 import software.bernie.geckolib.renderer.GeoRenderer;
 import software.bernie.geckolib.renderer.layer.GeoRenderLayer;
 
-import java.util.Calendar;
 
 public class GeckoBeeRenderer extends GeoEntityRenderer<GeckoBee>
 {
-    protected boolean isChristmas;
-    protected boolean isAprilFool;
-
     public GeckoBeeRenderer(EntityRendererProvider.Context renderManager) {
         super(renderManager, new GeckoBeeModel());
-
-        Calendar calendar = Calendar.getInstance();
-        if (ProductiveBeesConfig.CLIENT.alwaysChristmas.get() || (calendar.get(Calendar.MONTH) + 1 == 12 && calendar.get(Calendar.DATE) >= 21 && calendar.get(Calendar.DATE) <= 26)) {
-            this.isChristmas = !ProductiveBeesConfig.CLIENT.neverChristmas.get();
-        }
-        if (calendar.get(Calendar.MONTH) + 1 == 4 && calendar.get(Calendar.DATE) == 1) {
-            this.isAprilFool = ProductiveBeesConfig.GENERAL.enableJokes.get();
-        }
 
         addRenderLayer(new JellyLayer(this));
         addRenderLayer(new ColoredLayer(this));
         addRenderLayer(new GlowingLayer(this));
-        if (this.isChristmas) {
-            addRenderLayer(new ChristmasLayer(this));
-        }
+        addRenderLayer(new ChristmasLayer(this));
     }
 
     @Override
     public void preRender(PoseStack poseStack, GeckoBee animatable, BakedGeoModel model, @Nullable MultiBufferSource bufferSource, @Nullable VertexConsumer buffer, boolean isReRender, float partialTick, int packedLight, int packedOverlay, int colour) {
         super.preRender(poseStack, animatable, model, bufferSource, buffer, isReRender, partialTick, packedLight, packedOverlay, colour);
         if (!isReRender) {
-            if ((isAprilFool && !animatable.getRenderTransform().equals("flipped")) || (!isAprilFool && animatable.getRenderTransform().equals("flipped"))) {
+            boolean aprilFool = ProductiveBeeRenderer.isAprilFool();
+            if ((aprilFool && !animatable.getRenderTransform().equals("flipped")) || (!aprilFool && animatable.getRenderTransform().equals("flipped"))) {
                 poseStack.translate(0.0D, animatable.getBbHeight() + 0.1F, 0.0D);
                 poseStack.mulPose(Axis.ZP.rotationDegrees(180.0F));
             }
@@ -67,7 +54,7 @@ public class GeckoBeeRenderer extends GeoEntityRenderer<GeckoBee>
         this.model.getBone("stinger").ifPresent(geoBone -> {
             geoBone.setHidden(animatable.hasStung() || animatable.isStingless());
         });
-        if (!this.isChristmas) {
+        if (!ProductiveBeeRenderer.isChristmas()) {
             this.model.getBone("santahat").ifPresent(geoBone -> {
                 geoBone.setHidden(true);
             });
@@ -137,7 +124,7 @@ public class GeckoBeeRenderer extends GeoEntityRenderer<GeckoBee>
 
         @Override
         public void render(PoseStack poseStack, GeckoBee animatable, BakedGeoModel bakedModel, @Nullable RenderType renderType, MultiBufferSource bufferSource, @Nullable VertexConsumer buffer, float partialTick, int packedLight, int packedOverlay) {
-            if (!animatable.isInvisible() && BeeBodyLayer.baseTextures.containsKey(animatable.getRenderer()) && BeeBodyLayer.baseTextures.get(animatable.getRenderer()).containsKey("santahat")) {
+            if (ProductiveBeeRenderer.isChristmas() && !animatable.isInvisible() && BeeBodyLayer.baseTextures.containsKey(animatable.getRenderer()) && BeeBodyLayer.baseTextures.get(animatable.getRenderer()).containsKey("santahat")) {
                 renderType = RenderType.entityCutoutNoCull(BeeBodyLayer.baseTextures.get(animatable.getRenderer()).get("santahat"));
                 getRenderer().reRender(bakedModel, poseStack, bufferSource, animatable, renderType,
                         bufferSource.getBuffer(renderType), partialTick, 15728640, packedOverlay, -1);


### PR DESCRIPTION
## Summary
- Fixes #738 — startup hang caused by `IllegalStateException: Cannot get config value before config is loaded`
- Renderer constructors (`ProductiveBeeRenderer`, `GeckoBeeRenderer`) were reading config during `EntityRenderers.createEntityRenderers()`, which can run before the NeoForge config system finishes loading
- Instead of reading config in constructors, christmas/april-fools checks are now deferred to static methods called at render time with a 60-second cache (essentially zero overhead)
- Added `enableAprilFoolRendering` as a CLIENT config option since the server-side `enableJokes` isn't available during client rendering
- Bonus: config changes now take effect without restarting the game

## Changes
- **`ProductiveBeeRenderer`** — Removed `isChristmas`/`isAprilFool` instance fields. Added cached `isChristmas()`/`isAprilFool()` static methods that read config at render time
- **`BeeBodyLayer`** — Removed `isChristmas` constructor param, checks at render time via `ProductiveBeeRenderer.isChristmas()`
- **`GeckoBeeRenderer`** — Removed all config reads from constructor, uses `ProductiveBeeRenderer` static helpers
- **`DyeBeeRenderer`** — Updated to match new `BeeBodyLayer` constructor
- **`ProductiveBeesConfig`** — Added `enableAprilFoolRendering` client config