### PR TITLE
fix: bee cage name display bug when change language

### DIFF
--- a/src/main/java/cy/jdkdigital/productivebees/common/item/BeeCage.java
+++ b/src/main/java/cy/jdkdigital/productivebees/common/item/BeeCage.java
@@ -5,6 +5,7 @@ import cy.jdkdigital.productivebees.common.entity.bee.ConfigurableBee;
 import cy.jdkdigital.productivebees.common.entity.bee.ProductiveBee;
 import cy.jdkdigital.productivebees.init.ModAdvancements;
 import cy.jdkdigital.productivebees.util.BeeHelper;
+import cy.jdkdigital.productivebees.ProductiveBees;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.core.BlockPos;
@@ -216,10 +217,12 @@ public class BeeCage extends Item
     public Component getName(ItemStack stack) {
         if (!isFilled(stack)) {
             return Component.translatable(this.getDescriptionId());
+        } else {
+            String typeId = ((CustomData) stack.get(DataComponents.CUSTOM_DATA)).copyTag().getString("type");
+            String entityId = ((CustomData) stack.get(DataComponents.CUSTOM_DATA)).copyTag().getString("entity");
+            // return Component.translatable(self.getDescriptionId()).append(Component.literal(" (" + entityId + ")"));
+            return Component.translatable(this.getDescriptionId()).append(Component.literal(" (")).append(getTranslationKey(typeId, entityId)).append(Component.literal(")"));
         }
-
-        String entityId = stack.get(DataComponents.CUSTOM_DATA).copyTag().getString("name");
-        return Component.translatable(this.getDescriptionId()).append(Component.literal(" (" + entityId + ")"));
     }
 
     @Override
@@ -242,6 +245,29 @@ public class BeeCage extends Item
             } else {
                 pTooltipComponents.add(Component.translatable("productivebees.information.hold_shift").withStyle(ChatFormatting.WHITE));
             }
+        }
+    }
+
+    private Component getTranslationKey(String typeId, String entityId) {
+        boolean should_add_prefix = true;
+        String id;
+        if (entityId.equals(ProductiveBees.MODID + ":configurable_bee")) {
+            id = typeId;
+        } else {
+            id = entityId;
+            should_add_prefix = false;
+        }
+        String[] splits = id.split(":");
+        if (splits.length < 2) {
+            return Component.literal(id);
+        }
+        // gen an entity.productivebee.xxx_bee name from lang.json
+        Component translatable = Component.translatable("entity." + ProductiveBees.MODID + "." + (id.split(":"))[1] + (should_add_prefix ? "_bee" : ""));
+        // equal return or base return
+        if (translatable.getString().equals(id)) {
+            return Component.literal(id);
+        } else {
+            return translatable;
         }
     }
 }


### PR DESCRIPTION
Original bee cage name is from ItemTag "name", However it's hard coded, it perform wrong when you change your language and for some special configured bee in some modpacks, the name can not be saved correctly:

In first shoot, the whole name should be one language, not two.
<img width="854" height="480" alt="Snipaste_2026-06-23_12-14-24" src="https://github.com/user-attachments/assets/b1fa9253-231a-492f-9ba7-c0a87e28de45" />
<img width="854" height="480" alt="Snipaste_2026-06-23_12-15-17" src="https://github.com/user-attachments/assets/827d2878-cb72-4972-83dd-14ff7021ee88" />

Just change the display from name to transkey which read from a filed constructed with a normal synatx, meanwhile keep a compare and return a default, this can perform well for configurable_bee too.

<img width="854" height="480" alt="Snipaste_2026-06-23_12-26-53" src="https://github.com/user-attachments/assets/3be32cd8-7319-4ed7-8034-c8fb473de883" />
<img width="854" height="480" alt="Snipaste_2026-06-23_12-27-31" src="https://github.com/user-attachments/assets/24d29c3f-80fb-4635-b3b8-e7cdbd95b35e" />

