### PR TITLE
Fix water bottle output component in bottler recipe

### DIFF
--- a/src/main/resources/data/productivebees/recipe/bottler/water_bottle.json
+++ b/src/main/resources/data/productivebees/recipe/bottler/water_bottle.json
@@ -9,6 +9,10 @@
   },
   "result": {
     "id": "minecraft:potion",
-    "nbt": "{\"Potion\": \"minecraft:water\"}"
+    "components": {
+      "minecraft:potion_contents": {
+        "potion": "minecraft:water"
+      }
+    }
   }
 }


### PR DESCRIPTION
The bottler water bottle recipe still uses the legacy `nbt` field for the potion type. On 1.21.1, this produces a potion without valid potion contents instead of a water bottle.

This replaces the legacy NBT with the `minecraft:potion_contents` component.

I tested the updated recipe through a datapack override and confirmed that the Bottler now produces a proper Water Bottle.